### PR TITLE
/function-contract/behviors/ex-3-triangle-answer.c preconditions fix

### DIFF
--- a/code/function-contract/behaviors/ex-3-triangle-answer.c
+++ b/code/function-contract/behaviors/ex-3-triangle-answer.c
@@ -4,6 +4,11 @@ enum Sides { SCALENE, ISOSCELE, EQUILATERAL };
 enum Angles { RIGHT, ACUTE, OBTUSE };
 
 /*@
+  requires a <= b+c && a >= b && a >= c ;
+  requires 0 <= a && a*a <= INT_MAX;
+  requires 0 <= b && b*b <= INT_MAX;
+  requires 0 <= c && c*c <= INT_MAX;
+
   assigns \nothing;
 
   behavior equilateral:
@@ -18,18 +23,18 @@ enum Angles { RIGHT, ACUTE, OBTUSE };
   behavior scalene:
     assumes a != b && a != c && b != c ;
     ensures \result == SCALENE;
-  
+
   disjoint behaviors;
   complete behaviors;
 */
-enum Sides sides_kind(int a, int b, int c){
-  if(a == b && b == c){
-    return EQUILATERAL ;
-  } else if(a == b || b == c || a == c){
-    return ISOSCELE ;
-  } else {
-    return SCALENE ;
-  }
+enum Sides sides_kind(int a, int b, int c) {
+    if (a == b && b == c) {
+        return EQUILATERAL ;
+    } else if (a == b || b == c || a == c) {
+        return ISOSCELE ;
+    } else {
+        return SCALENE ;
+    }
 }
 
 /*@
@@ -37,7 +42,7 @@ enum Sides sides_kind(int a, int b, int c){
   requires 0 <= a && a*a <= INT_MAX;
   requires 0 <= b && b*b <= INT_MAX;
   requires 0 <= c && c*c <= INT_MAX;
-  
+
   assigns \nothing;
 
   behavior obtuse:
@@ -55,13 +60,13 @@ enum Sides sides_kind(int a, int b, int c){
   disjoint behaviors;
   complete behaviors;
 */
-enum Angles angles_kind(int a, int b, int c){
-  if(a*a - b*b > c*c){
-    return OBTUSE;
-  } else if(a*a - b*b < c*c){
-    return ACUTE;
-  } else {
-    return RIGHT;
-  }
+enum Angles angles_kind(int a, int b, int c) {
+    if (a * a - b * b > c * c) {
+        return OBTUSE;
+    } else if (a * a - b * b < c * c) {
+        return ACUTE;
+    } else {
+        return RIGHT;
+    }
 }
 

--- a/code/function-contract/behaviors/ex-3-triangle-answer.c
+++ b/code/function-contract/behaviors/ex-3-triangle-answer.c
@@ -4,10 +4,10 @@ enum Sides { SCALENE, ISOSCELE, EQUILATERAL };
 enum Angles { RIGHT, ACUTE, OBTUSE };
 
 /*@
-  requires a <= b+c && a >= b && a >= c ;
-  requires 0 <= a && a*a <= INT_MAX;
-  requires 0 <= b && b*b <= INT_MAX;
-  requires 0 <= c && c*c <= INT_MAX;
+  requires 0 <= a && 0 <= b && 0 <= c;
+  requires a >= b && a >= c; // Note that this condition is not
+                             // necessary for the function but
+                             // added for this exercise
 
   assigns \nothing;
 

--- a/code/function-contract/behaviors/ex-3-triangle-answer.c
+++ b/code/function-contract/behaviors/ex-3-triangle-answer.c
@@ -28,13 +28,13 @@ enum Angles { RIGHT, ACUTE, OBTUSE };
   complete behaviors;
 */
 enum Sides sides_kind(int a, int b, int c) {
-    if (a == b && b == c) {
-        return EQUILATERAL ;
-    } else if (a == b || b == c || a == c) {
-        return ISOSCELE ;
-    } else {
-        return SCALENE ;
-    }
+  if (a == b && b == c) {
+    return EQUILATERAL ;
+  } else if (a == b || b == c || a == c) {
+    return ISOSCELE ;
+  } else {
+    return SCALENE ;
+  }
 }
 
 /*@
@@ -61,12 +61,12 @@ enum Sides sides_kind(int a, int b, int c) {
   complete behaviors;
 */
 enum Angles angles_kind(int a, int b, int c) {
-    if (a * a - b * b > c * c) {
-        return OBTUSE;
-    } else if (a * a - b * b < c * c) {
-        return ACUTE;
-    } else {
-        return RIGHT;
-    }
+  if (a * a - b * b > c * c) {
+    return OBTUSE;
+  } else if (a * a - b * b < c * c) {
+    return ACUTE;
+  } else {
+    return RIGHT;
+  }
 }
 


### PR DESCRIPTION
Insert preconditions for asserting triangle inequality and that `a` is the hypotenuse of the triangle. While these were included in the angles_kind() function contact, they were missing from the sides_kind() function contract.