### PR TITLE
typo in ch4, Section 4.1.1. first formula

### DIFF
--- a/english/statements/basic.tex
+++ b/english/statements/basic.tex
@@ -5,7 +5,7 @@
 Assignment is the most basic operation one can have in an imperative
 language (leaving aside the ``do nothing'' operation that is not particularly
 interesting). The weakest precondition calculus associates the following
-$$wp(x = E , Post) := Post[x \leftarrow E]$$
+$$wp(x = E , Post) := P[x \leftarrow E]$$
 
 
 Here the notation $P[x \leftarrow E]$ means ``the property $P$ where


### PR DESCRIPTION
This is a typo in ch4, Section 4.1.1. first formula.