### PR TITLE
Add triangle inequality to preconditions

### DIFF
--- a/code/function-contract/behaviors/ex-3-triangle-answer.c
+++ b/code/function-contract/behaviors/ex-3-triangle-answer.c
@@ -5,6 +5,7 @@ enum Angles { RIGHT, ACUTE, OBTUSE };
 
 /*@
   requires 0 <= a && 0 <= b && 0 <= c;
+  requires a <= b+c;
   requires a >= b && a >= c; // Note that this condition is not
                              // necessary for the function but
                              // added for this exercise


### PR DESCRIPTION
Otherwise, the function would accept (a=3, b=1, c=1), which is not a valid triangle.

In other words, this function call would pass all checks even though (3,1,1) is not a triangle, while the exercise explicitly requires sides_kind() to verify that the arguments are a valid triangle:
```c
enum Sides test_sides_kind() {
    return sides_kind(3, 1, 1);
}
```
With the added precondition, it should not accept invalid triangles anymore (AFAICS), including the test code above.

Note that PR #21 was meant to fix this issue and this precondition was added in the initial submission. However, after the PR was modified the precondition was no longer added, which means that in the end, that PR didn't actually fix this issue.