### PR TITLE
Exercise 4.3.3.3: fix ambiguous result in binary search

### DIFF
--- a/code/statements/loops-examples/ex-3-binary-search-u-answer.c
+++ b/code/statements/loops-examples/ex-3-binary-search-u-answer.c
@@ -1,5 +1,5 @@
 #include <stddef.h>
-#include <limits.h>
+#include <stdint.h>
 
 /*@
   requires \valid_read(arr + (0 .. len-1));
@@ -12,23 +12,24 @@
     assumes \exists integer j ; 0 <= j < len && arr[j] == value ;
     ensures 0 <= \result < len ;
     ensures arr[\result] == value ;
+    ensures \result != SIZE_MAX ;
 
   behavior does_not_exists:
     assumes \forall integer j ; 0 <= j < len ==> arr[j] != value ;
-    ensures \result == UINT_MAX ;
+    ensures \result == SIZE_MAX ;
 
   complete behaviors ;
   disjoint behaviors ;
 */
 size_t bsearch(int* arr, size_t len, int value){
-  if(len == 0) return UINT_MAX ;
-  
+  if(len == 0) return SIZE_MAX ;
+
   size_t low = 0 ;
   size_t up = len ;
 
   /*@
     loop invariant 0 <= low && up <= len ;
-    loop invariant 
+    loop invariant
       \forall integer i ; 0 <= i < len && arr[i] == value ==> low <= i < up ;
     loop assigns low, up ;
     loop variant up - low ;
@@ -39,5 +40,5 @@ size_t bsearch(int* arr, size_t len, int value){
     else if(arr[mid] < value) low = mid+1 ;
     else return mid ;
   }
-  return UINT_MAX ;
+  return SIZE_MAX ;
 }


### PR DESCRIPTION
The provided answer was returning UINT_MAX as the result when the value
was not found in the array.

Since UINT_MAX == (2^32 - 1) on x86_64-unknown-linux-gnu, this means that
if the array has 2^32 or more elements and bsearch() finds the value to
exist in the array at index (2^32 - 1), then it is ambiguous whether the
result of the function call indicates whether the value was found at that
index or whether the value was not found.

To prevent this ambiguity, a postcondition was added ensuring that if the value
is found, then the result must not be the same as when the value is not
found.

This will not pass verification when the "not found" result is UINT_MAX
because `len` can be larger than that, so I increased the "not
found" result to be SIZE_MAX instead of UINT_MAX.

SIZE_MAX is not actually always guaranteed to be the maximum value of
size_t on all platforms, but now we will at least get a verification
error if that happens.

Probably, the most correct way to fix this would be to calculate the
real maximum value of size_t (something like 2^(CHAR_BIT *
sizeof(size_t)) − 1), but that seems a bit too cumbersome.

Alternatively, we could just return `len` when the value is not found,
which is simple and always guaranteed to work, but that does seem a bit
unidiomatic in C...