### PR TITLE
Spell checking + changes some definitions

### DIFF
--- a/english/acsl-logic-definitions.tex
+++ b/english/acsl-logic-definitions.tex
@@ -1,5 +1,4 @@
 In this part of the tutorial, we will present three important notions of ACSL:
-
 \begin{itemize}
 \item inductive definitions,
 \item axiomatic definitions,

--- a/english/acsl-logic-definitions/axiomatic.tex
+++ b/english/acsl-logic-definitions/axiomatic.tex
@@ -112,7 +112,7 @@ axiomatically as follows:
 
 
 
-In this axiomatic definition, our function has no body. Its
+In this axiomatic definition, our function does not have a body. Its
 behavior is only defined by the axioms we have stated about it.
 Except this, nothing changes, in particular the logic function can
 be used in our specification just as before.
@@ -152,7 +152,7 @@ an information for axiomatically defined properties.
 
 By adding axioms to our knowledge base, we can produce more complex
 proofs since some part of these proofs, expressed by axioms, do not need
-to be proved anymore (they are already specified to be true) shortening
+to be proved (they are already specified to be true) shortening
 the proof process. However, using axiomatic definitions, \textbf{we must
 be extremely careful}. Indeed, even a small error could introduce false
 in the knowledge base, making our whole reasoning futile. Our reasoning
@@ -215,20 +215,14 @@ axiomatic definition, removing the specification of the values that are
 read by the predicate (\CodeInline{reads a[b .. e-1]}), the proof
 will still be performed, but will not prove anything about the content
 of the arrays. For example, the following function:
-
-
-
 \CodeBlockInput[16][25]{c}{all-zeroes-bad.c}
-
-
-
 is proved to be correct, while we obviously changed a value in the array
 and the value is not 0 anymore.
 
 
 
 Note that unlike inductive definitions, where Why3 provides us a way to control
-that what we write in ACSL is relatively well defined, we do not have such a
+that what we write in ACSL is relatively well-defined, we do not have such a
 mechanism for axiomatic definitions. Basically, even with Why3 such a definition
 is translated into a list of axioms that are thus assumed.
 
@@ -248,7 +242,6 @@ what is the number of occurrences of a value in an array:
 
 
 We have three different cases:
-
 \begin{itemize}
 \item
   the considered range of values is empty: the number of occurrences is
@@ -262,7 +255,6 @@ We have three different cases:
   not the one we are searching for: the number of occurrences is the number
   of occurrences in the current range without the last element.
 \end{itemize}
-
 Then, we can write the C function that computes the number of
 occurrences of a value in an array and prove it:
 
@@ -298,7 +290,7 @@ Here, we still have to realize the proof of the lemma to get a complete
 proof.
 
 
-\levelThreeTitle{Example: The strlen function}
+\levelThreeTitle{Example: The \texttt{strlen} function}
 
 
 In this section, let us prove the C \CodeInline{strlen} function:
@@ -340,7 +332,7 @@ a contract for \CodeInline{strlen}:
 
 
 
-Defining the logic function \CodeInline{strlen} is a bit tricky. Indeed
+Defining the logic function \CodeInline{strlen} is a bit tricky. Indeed,
 we want to compute the length of a string by finding the character
 \CodeInline{'\textbackslash{}0'}, we expect to find it but in fact, we
 can easily imagine that we receive a string of infinite length. In this case,
@@ -388,7 +380,6 @@ the variant corresponds to the distance between \CodeInline{i} and
 correctness of the function, it fails. And to get more information
 we can try a verification asking RTE with the verification that unsigned
 integers do not overflow:
-
 
 
 

--- a/english/acsl-logic-definitions/ghost-code.tex
+++ b/english/acsl-logic-definitions/ghost-code.tex
@@ -171,14 +171,11 @@ void foo(unsigned n){
 
 
 Frama-C verifies several properties about the ghost code we write:
-
-
 \begin{itemize}
 \item the ghost code cannot modify the control flow graph of the program,
 \item the normal code cannot access to the ghost memory,
 \item the ghost code can only write the ghost memory.
 \end{itemize}
-
 
 Verifying these properties, our goal is to guarantee that for any
 program, for any input, its observable behavior is the same with or
@@ -268,8 +265,8 @@ an error will still be triggered:
 Finally, we can remark that there exists two ways to change the control
 flow. The first one is to use jumps (thus \CodeInline{break},
 \CodeInline{continue}, or \CodeInline{goto}), the second is to
-introduce a non terminating code. For this last one, unless the non
-termination is trivial, the kernel cannot verify that the control
+introduce a non-terminating code. For this last one, unless the non-termination
+is trivial, the kernel cannot verify that the control
 flow is changed (and thus, it never does, this is delegated to plugins).
 We will treat this question in
 section~\ref{l3:acsl-logic-definitions-what-remains}.
@@ -461,7 +458,7 @@ int const * p = a ;
 
 This code is valid as we only restrict our capacity to write memory
 locations when we initialize (or assign) \CodeInline{p} to \CodeInline{\&a[0]}.
-On the other hand, both the two following pointer initializations
+On the other hand, both the two following pointer initialization
 (or equivalent assignments) are forbidden with the
 \CodeInline{\textbackslash{}ghost} qualifier:
 
@@ -476,7 +473,7 @@ int non_ghost_int ;
 
 
 While the reason why we refuse the first initialization is quite direct:
-it would allow to write into the normal memory from ghost code through
+it would allow writing into the normal memory from ghost code through
 \CodeInline{p}, the reason why we refuse the second one is not that
 intuitive. And, indeed, we must use workarounds to create a problem with
 this conversion:
@@ -501,15 +498,13 @@ not currently supported by Frama-C.
 
 
 \levelThreeTitle{Ghost code validity, what remains to be verified}
-\label{l3:acsl-logic-definitions-what-remains}.
+\label{l3:acsl-logic-definitions-what-remains}
 
 
 Except for the restrictions mentioned in the previous section,
 ghost code is just normal C code. That means that if we want to
 verify the original program, we must take care of at least two more
 aspects:
-
-
 \begin{itemize}
 \item absence of runtime errors,
 \item ghost code termination.
@@ -526,7 +521,7 @@ kinds of correctness: partial and total correctness, the second one allowing
 to prove that a program terminates. For normal code, showing that the code
 terminates is not always something that we want. On the other hand, if we
 use some ghost code during the verification, it is absolutely necessary to
-prove total correctness of this ghost code. Indeed, if it is non terminating
+prove total correctness of this ghost code. Indeed, if it is non-terminating
 (if it contains an infinite loop for example), it could allow us to prove
 anything about the program.
 
@@ -545,8 +540,8 @@ void foo(void){
 \levelThreeTitle{Make a logical state explicit}
 
 
-The goal of ghost code is to make explicit some information that would else
-be implicit. For example, in the verification of the sort algorithm, we used it
+The goal of ghost code is to make explicit some information that would be else
+implicit. For example, in the verification of the sort algorithm, we used it
 to create a label in the program that is not visible by the compiler but that
 we can use in the verification. The fact that the values were swapped between the
 two labels was implicitly provided by the contract of the function, adding this
@@ -599,8 +594,8 @@ equal to the sum of the elements between these bounds, and there must
 exist some bounds such that the returned value is exactly the sum of the
 elements between these bounds. About this specification, when we want to
 add the loop invariant, we realize that we miss some information.
-We want to express what are the values \CodeInline{max} and \CodeInline{cur} and
-what are the relations between them, but we cannot do it!
+We want to express what are the values \CodeInline{max} and \CodeInline{cur},
+and what are the relations between them, but we cannot do it!
 
 
 Basically, in order to prove our postcondition, we need to know that there
@@ -617,7 +612,7 @@ of the maximum sum range, let us call them \CodeInline{low} and
 \CodeInline{high}. Every time we find a range where the sum is greater
 than the current one, we update our ghost variables. These bounds
 then correspond to the sum currently stored by \CodeInline{max}. That
-induces that we need other bounds: the ones that corresponds to the sum
+induces that we need other bounds: the ones that correspond to the sum
 stored by the variable \CodeInline{cur} from which we build the bounds
 corresponding to \CodeInline{max}. For these bounds, we only add a
 single ghost variable: the current low bound \CodeInline{cur\_low}, the high

--- a/english/acsl-logic-definitions/inductive.tex
+++ b/english/acsl-logic-definitions/inductive.tex
@@ -135,7 +135,7 @@ For example for our definition of \CodeInline{even\_natural}, we would write:
 
 
 
-During the generation of the proof obligation, WP asks Why3 to create an
+During the generation of the verification conditions, WP asks Why3 to create an
 inductive definition from the one written in ACSL. As Why3 is stricter than
 Frama-C and WP on this kind of definition, if the inductive predicate is too
 strange (if it is not well-founded), it will be rejected with an error. And

--- a/english/acsl-logic-definitions/inductive.tex
+++ b/english/acsl-logic-definitions/inductive.tex
@@ -141,8 +141,8 @@ Frama-C and WP on this kind of definition, if the inductive predicate is too
 strange (if it is not well-founded), it will be rejected with an error. And
 indeed, with the bad definition of \CodeInline{even\_natural} we just proposed,
 Why3 complains when we try to prove the
-\CodeInline{ensures \textbackslash{}false}, because there exists a non
-positive occurrence of \CodeInline{P\_even\_natural} that encodes the
+\CodeInline{ensures \textbackslash{}false}, because there exists a
+non-positive occurrence of \CodeInline{P\_even\_natural} that encodes the
 \CodeInline{even\_natural} we wrote in ACSL.
 
 \begin{CodeBlock}{bash}

--- a/english/acsl-logic-definitions/inductive.tex
+++ b/english/acsl-logic-definitions/inductive.tex
@@ -44,11 +44,11 @@ Which perfectly describes the two cases:
 
 However, this definition is not completely satisfying. For example, we cannot
 deduce that an odd number is not even. If we try to prove that 1 is even, we
-will have to check if -1 is even, and then -3, -5, etc, infinitely. Moreover,
+will have to check if -1 is even, and then -3, -5, etc., infinitely. Moreover,
 we generally prefer to define the induction cases the opposite way: defining
 the condition under which the wanted conclusion is true. For example, here,
 how can we verify that some $n$ is natural and even? We first check whether it
-is 0, if not, we check if $n$ is greater than $0$ and then we verify that $n-2$
+is 0, if not, we check if $n$ is greater than $0$, and then we verify that $n-2$
 is even:
 
 
@@ -91,13 +91,11 @@ avoid building such a bad definition.
 First, we can make sure that inductive predicates are well-founded. This can
 be done by syntactically restricting what we allow in an inductive definition,
 by making sure that each case has the form:
-
 \begin{CodeBlock}{c}
 /*@
   \forall y1,...,ym ; h1 ==> ··· ==> hl ==> P(t1,...,tn) ;
 */
 \end{CodeBlock}
-
 where the predicate \CodeInline{P} can only appear positively (so not negated
 with \CodeInline{!} - $\neg$) in the different hypotheses \CodeInline{hx}.
 Basically, it ensures that we cannot build both positive and negative
@@ -105,9 +103,7 @@ occurrences of \CodeInline{P} for some parameters which would be incoherent.
 
 This is for example verified by our previously defined predicate
 \CodeInline{even\_natural}. While a definition like:
-
 \CodeBlockInput[5][15]{c}{even-bad.c}
-
 does not respect this constraint as the property \CodeInline{even\_natural}
 appears negatively on line~8.
 
@@ -141,9 +137,9 @@ Frama-C and WP on this kind of definition, if the inductive predicate is too
 strange (if it is not well-founded), it will be rejected with an error. And
 indeed, with the bad definition of \CodeInline{even\_natural} we just proposed,
 Why3 complains when we try to prove the
-\CodeInline{ensures \textbackslash{}false}, because there exists a
+\CodeInline{ensures \textbackslash{}false} clause, because there exists a
 non-positive occurrence of \CodeInline{P\_even\_natural} that encodes the
-\CodeInline{even\_natural} we wrote in ACSL.
+\CodeInline{even\_natural} predicate we wrote in ACSL.
 
 \begin{CodeBlock}{bash}
 frama-c-gui -wp -wp-prop=BAD file.c
@@ -304,8 +300,8 @@ This time, our property is precisely defined, the proof is relatively easy to
 produce, only requiring to add an assertion in the block of the loop to state
 that it only performs a swap of values in the array (and then giving
 the transition to the next permutation). To define this swap notion, we use
-a particular annotation (at line 16), introduced using the keyword
-\CodeInline{ghost}. Here, the goal is to introduce a label in the code that in
+a particular annotation (at line 16), introduced using the \CodeInline{ghost}
+keyword. Here, the goal is to introduce a label in the code that in
 fact does not exist from the program point of view, and is only visible from
 a specification point of view. We present the ``ghost'' features in the final
 section of this chapter, for now let us focus on axiomatic definitions.
@@ -340,7 +336,7 @@ divisor of two others. The goal of the exercise is to prove that the function
 \CodeInline{gcd} computes the greatest common divisor. Thus, we do not have to
 specify all the cases for the predicate. Indeed, a close look at the loop shows
 us that after the first iteration \CodeInline{a} is greater or equals to
-\CodeInline{b} and it is maintained by the loop. Thus, we consider two cases for
+\CodeInline{b}, and it is maintained by the loop. Thus, we consider two cases for
 the inductive predicate:
 
 
@@ -367,7 +363,7 @@ In this exercise, we do not consider RTEs.
 
 
 Write an inductive predicate that states that some integer \CodeInline{r} equals
-to $x^n$. Consider the two cases: either $n$ is 0 or it is greater and then it
+to $x^n$. Consider the two cases: either $n$ is 0 or it is greater, and then it
 should be related to the value $x^{n-1}$.
 
 
@@ -423,10 +419,10 @@ thus $p^n = 1$.
 Take back the definitions of the \CodeInline{shifted} and \CodeInline{unchanged}
 predicates from the exercise~\ref{l4:acsl-properties-lemmas-shift-trans}. The
 \CodeInline{shited\_cell} predicate can be inlined and removed. Use the
-shift predicate to express the rotate predicate that expresses that some elements
-of an array are rotated to the left in the sense that all elements are shifted of
-one element to the left except the last one that is put in the first cell of the
-range. Use this predicate to prove the rotate function:
+shift predicate to express the \CodeInline{rotate} predicate that expresses that
+some elements of an array are rotated to the left in the sense that all elements
+are shifted of one element to the left except the last one that is put in the
+first cell of the range. Use this predicate to prove the rotate function:
 
 
 \CodeBlockInput[16][31]{c}{ex-4-rotate-permutation.c}
@@ -434,7 +430,6 @@ range. Use this predicate to prove the rotate function:
 
 Express a new version of the notion of permutation with an inductive predicate
 that considers four cases:
-
 \begin{itemize}
 \item permutation is reflexive,
 \item if the left part of the range (until an index of the range) is rotated

--- a/english/acsl-properties.tex
+++ b/english/acsl-properties.tex
@@ -3,7 +3,7 @@ and logic functions provided by ACSL: \CodeInline{\textbackslash{}valid},
 \CodeInline{\textbackslash{}valid\_read}, \CodeInline{\textbackslash{}separated},
 \CodeInline{\textbackslash{}old} and \CodeInline{\textbackslash{}at}. There are others
 built-in predicates, but we will not present them all, the reader can refer to
-\externalLink{the documentation (ACSL implementation)}{http://frama-c.com/download.html}
+\externalLink{the documentation (ACSL implementation)}{https://frama-c.com/html/get-frama-c.html}
 (note that everything is not necessarily supported by WP).
 
 

--- a/english/acsl-properties.tex
+++ b/english/acsl-properties.tex
@@ -2,7 +2,7 @@ From the beginning of this tutorial, we have used different predicates
 and logic functions provided by ACSL: \CodeInline{\textbackslash{}valid},
 \CodeInline{\textbackslash{}valid\_read}, \CodeInline{\textbackslash{}separated},
 \CodeInline{\textbackslash{}old} and \CodeInline{\textbackslash{}at}. There are others
-built-in predicates but we will not present them all, the reader can refer to
+built-in predicates, but we will not present them all, the reader can refer to
 \externalLink{the documentation (ACSL implementation)}{http://frama-c.com/download.html}
 (note that everything is not necessarily supported by WP).
 

--- a/english/acsl-properties/functions.tex
+++ b/english/acsl-properties/functions.tex
@@ -218,7 +218,7 @@ have defined.
 \label{l4:acsl-properties-functions-n-first-ints}
 
 
-The following function compute the sum of the N first integers. Write a
+The following function computes the sum of the N first integers. Write a
 recursive logic functions that returns the sum of the N first integers and
 write a specification for the C function expressing that it computes the same
 value as provided by the logic function.

--- a/english/acsl-properties/lemmas.tex
+++ b/english/acsl-properties/lemmas.tex
@@ -4,7 +4,7 @@ can be proved in isolation of the rest of the proof of a program by automatic or
 it states can be safely used to simplify the reasoning in other, more complex
 proofs, without having to prove it again. For example, if we state a lemma $L$
 that says $P \Rightarrow Q$ in any case, if at some point in another proof, we
-have to prove $Q$ and we know $P$, we can directly conclude by using the lemma
+have to prove $Q$, and we know $P$, we can directly conclude by using the lemma
 $L$ without having to perform again the reasoning that brings us from $P$ to
 $Q$.
 
@@ -154,7 +154,7 @@ follows it and calls the binary search function.
 Take back your proved binary search function from the
 exercise~\ref{l4:acsl-properties-predicates-ex-bsearch}. You might notice that
 the precondition of the binary search function is stronger than what we know in
-precondition of the \CodeInline{bsearch\_callee}. However, our precondition
+precondition of the \CodeInline{bsearch\_callee} function. However, our precondition
 implies that the array is globally sorted. Write a lemma that states that if
 an array is \CodeInline{element\_level\_sorted} then it is \CodeInline{sorted}.
 This lemma will probably not be proved by SMT solvers, all remaining properties

--- a/english/acsl-properties/predicates.tex
+++ b/english/acsl-properties/predicates.tex
@@ -159,15 +159,15 @@ can occur).
 
 Taking back the solution of the
 exercise~\ref{l4:contract-modularity-ex-days-of-month} about days of the month,
-write a predicate to express that a year is leap and adapt the contracts using
-it.
+write a predicate to express that a year is a leap year and adapt the contracts
+using it.
 
 
-\levelFourTitle{Alpha-numeric character}
+\levelFourTitle{Alphanumeric character}
 
 
 Taking back the solution of the
-exercise~\ref{l4:contract-modularity-ex-alpha-num} about alpha numeric
+exercise~\ref{l4:contract-modularity-ex-alpha-num} about alphanumeric
 characters, write predicates to express that a character is an upper letter,
 lower letter, and a digit. Adapt the contracts of the different functions using
 them.

--- a/english/acsl-properties/some-logical-types.tex
+++ b/english/acsl-properties/some-logical-types.tex
@@ -1,6 +1,6 @@
 ACSL provides different logic types that allow us to write properties in a more
 abstract, mathematical world. Among the types that can be useful, some are
-dedicated to numbers, and allow to express properties or functions without
+dedicated to numbers, and allow expressing properties or functions without
 having to think about constraints due to the size of
 the representation of primitive C types in memory. These types are
 \CodeInline{integer} and \CodeInline{real}, which respectively represent
@@ -13,7 +13,7 @@ definitions are true regardless the size of the machine integer we have
 as input.
 
 On the other hand, we will not talk about the differences that exist
-between \CodeInline{real} and \CodeInline{float/double}. It would require to
-speak about precise numerical calculus, and about proofs of programs
+between \CodeInline{real} and \CodeInline{float/double}. It would require
+speaking about precise numerical calculus, and about proofs of programs
 that rely on such calculus which could deserve an entire dedicated
 tutorial.

--- a/english/conclusion.tex
+++ b/english/conclusion.tex
@@ -43,7 +43,7 @@ function, we can still write something like this:
 */
 void my_function(int* a, int b){
   //this is indeed the  "assert" defined in "assert.h"
-  assert(/*properties on a*/ && "must respect properties on a");  
+  assert(/*properties on a*/ && "must respect properties on a");
   assert(/*properties on b*/ && "must respect properties on b");
 }
 \end{CodeBlock}
@@ -99,8 +99,8 @@ academic and industrial world, in which we can read:
 
 \begin{Quotation}[Formal Methods for Security, 2016]
 Adoption of formal methods in various areas (including verification of hardware
-and embedded systems, and analysis and testing of software) has dramatically 
-improved the quality of computer systems.  We anticipate that formal methods 
+and embedded systems, and analysis and testing of software) has dramatically
+improved the quality of computer systems.  We anticipate that formal methods
 can provide similar improvement in the security of computer systems.
 
 ...
@@ -158,7 +158,7 @@ the source code and Frama-C allows to build them as easily as possible.
 \levelThreeTitle{With deductive proof}
 
 
-Along this tutorial we used WP to generate proof obligation starting
+Along this tutorial we used WP to generate verification conditions starting
 from programs with their specification. Next we have used automatic
 solvers to assure that these properties were indeed verified.
 
@@ -176,7 +176,7 @@ interesting to study
 this language. In the context of Frama-C, we can produce reusable lemmas
 libraries proved with Coq. But Coq can also be used for many
 different tasks, including programming. Note that Why3 can also extract
-its proof obligations to Isabelle or PVS that are also proof assistants.
+its verification conditions to Isabelle or PVS that are also proof assistants.
 
 Finally, there exists other program logics, for example separation logic
 or concurrent program logics. Again these notions are interesting to know

--- a/english/conclusion.tex
+++ b/english/conclusion.tex
@@ -20,8 +20,8 @@ to the use of C (namely, the absence of runtime errors).
 Starting from specified programs, WP is able to produce the weakest
 precondition of our functions, provided what we want in postcondition,
 and to ask some provers if the specified precondition is compatible with
-the computed one. The reasoning is completely modular, which allows to
-prove functions in isolation from each other and to compose the results.
+the computed one. The reasoning is completely modular, which allows
+proving functions in isolation from each other and to compose the results.
 
 
 WP cannot currently work with dynamic allocation. A function that would use it
@@ -55,7 +55,7 @@ the possibility to debug an incorrect call in a source code that we
 cannot or do not want to prove.
 
 Writing specifications is sometimes long or tedious. Higher-level
-features of ACSL (predicates, logic functions, axiomatizations) allow us
+features of ACSL (predicates, logic functions, axioms) allow us
 to lighten this work, as well as our programming languages allow us to
 define types containing other types, functions calling functions, bringing
 us to the final program. But, despite this, write specification in a
@@ -83,14 +83,14 @@ based on ideas born at the beginning of the tools, 30 years ago. Our tools
 evolve, the ways we develop change, probably faster than in any other
 technical domain. Saying that these tools could never be
 used for real life programs would certainly be a too big shortcut. After
-all, we see everyday how much development is different from what it were
+all, we see every day how much development is different from what it were
 10 years, 20 years, 40 years ago and can barely imagine how much it will
 be different in 10 years, 20 years, 40 years.
 
 During the past few years, safety and security questions have become
 more and more visible and crucial. Formal methods also progressed a lot,
 and the improvement they bring for these questions are greatly
-appreciated. For example, this
+appreciated. For example,
 \externalLink{this link}{http://sfm.seas.harvard.edu/report.html} brings to the
 report of a conference about security that brought together people from
 academic and industrial world, in which we can read:
@@ -116,10 +116,9 @@ can provide similar improvement in the security of computer systems.
 \levelThreeTitle{With Frama-C}
 
 
-Frama-C provides different ways to analyse programs. Among these tools, the
+Frama-C provides different ways to analyze programs. Among these tools, the
 most commonly used and interesting to know from a static and dynamic
-verification point of view are certainly those ones:
-
+verification point of view are certainly those:
 \begin{itemize}
 \item abstract interpretation analysis using
 \externalLink{EVA}{http://frama-c.com/value.html},
@@ -130,15 +129,15 @@ verification point of view are certainly those ones:
 The goal of the first one is to compute the domain of the different
 variables at each program point. When we precisely know these domains,
 we can determine if these variables can produce errors when they are
-used. However this analysis is executed on the whole program and not
+used. However, this analysis is executed on the whole program and not
 modularly. It is also strongly dependent of the type of domain we use (we
 will not enter into details here) and it is not so good at keeping the
 relations between variables. On the other side, it is really completely
 automatic, we do not even need to give loop invariant! The most manual
-part of the work is to determine whether or not an alarm is a true error
+part of the work is to determine whether an alarm is a true error
 or a false positive.
 
-The second analysis allows to generate from an original program, a new
+The second analysis allows generating from an original program, a new
 program where the assertions are transformed into runtime verifications.
 If these assertions fail, the program fails. If they are valid, the
 program has the same behavior it would have without the assertions. An
@@ -175,7 +174,7 @@ Why3, can extract its verification conditions to Coq, and it is very
 interesting to study
 this language. In the context of Frama-C, we can produce reusable lemmas
 libraries proved with Coq. But Coq can also be used for many
-different tasks, including programming. Note that Why3 can also extract
+tasks, including programming. Note that Why3 can also extract
 its verification conditions to Isabelle or PVS that are also proof assistants.
 
 Finally, there exists other program logics, for example separation logic

--- a/english/function-contract/behaviors.tex
+++ b/english/function-contract/behaviors.tex
@@ -18,8 +18,8 @@ keyword \CodeInline{\textbackslash{}old} cannot be used there). However,
 the properties expressed by this clause do not have to be verified before
 the call, they can be verified and in this case, the postcondition
 specified in our behavior applies. The postconditions of a particular
-behavior are introduced using \texttt{ensures}. Finally, we can ask WP to
-verify that behaviors are disjoint (to guarantee determinism) and
+behavior are introduced using a \texttt{ensures} clause. Finally, we can ask WP
+to verify that behaviors are disjoint (to guarantee determinism) and
 complete (to guarantee that we cover all possible input).
 
 Behaviors are disjoint if for any (valid) input of the function, it
@@ -41,9 +41,8 @@ return a positive value.
 
 
 
-Let us now slighlty modify the assumptions of each behavior to illustrate
+Let us now slightly modify the assumptions of each behavior to illustrate
 the meaning of \CodeInline{complete} and \CodeInline{disjoint}:
-
 \begin{itemize}
 \item
   replace the assumption of \CodeInline{pos} with
@@ -64,7 +63,7 @@ the meaning of \CodeInline{complete} and \CodeInline{disjoint}:
   \begin{itemize}
   \item put our \CodeInline{assigns} before the behaviors (as we have done in our
     example) with all potentially modified non-local elements,
-  \item add in postcondition of each behaviors the elements that are in fact
+  \item add in postcondition of each behavior the elements that are in fact
     not modified by indicating their new value to be equal to the
     \CodeInline{\textbackslash{}old} one.
   \end{itemize}
@@ -83,12 +82,10 @@ tedious and again error-prone.
 \levelThreeTitle{Exercises}
 
 
-\levelFourTitle{Previous exercices}
+\levelFourTitle{Previous exercises}
 
 
 From previous sections, take back the examples:
-
-
 \begin{itemize}
 \item about the computation of the distance between to integers,
 \item ``reset on condition'',
@@ -106,7 +103,7 @@ Considering that the contracts were:
 Re-write them using behaviors.
 
 
-\levelFourTitle{Two other simple exercices}
+\levelFourTitle{Two other simple exercises}
 
 
 Produce the code and the specification of the two following functions
@@ -133,7 +130,6 @@ the coordinate is on an axis, arbitrary choose one of the quadrants.
 
 Complete the following functions that receive the lengths of the different
 sides of a triangle, and respectively return:
-
 \begin{itemize}
 \item if the triangle is scalene, isosceles, or equilateral,
 \item if the triangle is right, acute or obtuse.
@@ -170,13 +166,13 @@ the contract was:
 
 \begin{enumerate}
 \item Rewrite it using behaviors
-\item Modify the contract of 1. in order to make the behaviors non-disjoint,
+\item Modify the contract of 1 in order to make the behaviors non-disjoint,
   except this property, the contract should remain verified,
-\item Modify the contract of 1. in order to make the behaviors incomplete,
+\item Modify the contract of 1 in order to make the behaviors incomplete,
   add a new behavior that makes the contract complete again,
-\item Modify the function of 1. in order to accept \CodeInline{NULL} pointers
-  for both \CodeInline{a} and \CodeInline{b}. If both of them are nul pointers,
-  return \CodeInline{INT\_MIN}, if one is a nul pointer, return the value of
+\item Modify the function of 1 in order to accept \CodeInline{NULL} pointers
+  for both \CodeInline{a} and \CodeInline{b}. If both of them are null pointers,
+  return \CodeInline{INT\_MIN}, if one is a null pointer, return the value of
   the other, else, return the maximum of them. Modify the contract accordingly
   by adding new behaviors. Be sure that they are disjoint and complete.
 \end{enumerate}

--- a/english/function-contract/contract.tex
+++ b/english/function-contract/contract.tex
@@ -9,9 +9,6 @@ for the output. The expectation of the function is called the
 These properties are expressed with ACSL. The syntax is relatively
 simple if one has already developed in C language since it shares most
 of the syntax of boolean expressions in C. However, it also provides:
-
-
-
 \begin{itemize}
 \item
   some logic constructs and connectors that do not exist in C, to ease
@@ -63,7 +60,7 @@ later see how to express precondition).
 \levelThreeTitle{Postcondition}
 
 
-The postcondition of a function is introduced with the clause \CodeInline{ensures}.
+The postcondition of a function is introduced with the \CodeInline{ensures} clause.
 Let us illustrate its use with the following function
 that returns the absolute value of an input value. One of its postconditions
 is that the result (which is denoted with the keyword
@@ -82,7 +79,7 @@ the general behavior of a function returning the absolute value. That
 is: if the value is positive or 0, the function returns the same value,
 else it returns the opposite of the value.
 
-We can specify multiple postconditions, first by combining them with a
+We can specify multiple postconditions, first by combining them with an operator
 \CodeInline{\&\&} as we do in C, or by introducing a new \CodeInline{ensures}
 clause, as we illustrate here:
 
@@ -148,9 +145,10 @@ $T$ & $T$ & $F$ & $T$ & $T$ & $T$ & $T$ \\ \hline
 
 
 We can come back to our specification. As our files become longer and
-contains a lot of specifications, if can be useful to name the
+contains a lot of specifications, it can be useful to name the
 properties we want to verify. So, in ACSL, we can specify a name
-(without spaces) followed by a \CodeInline{:}, before stating the property.
+(without spaces) followed by a \CodeInline{:} character, before stating the
+property.
 It is possible to put multiple levels of names to categorize our
 properties. For example, we could write this:
 
@@ -161,13 +159,13 @@ properties. For example, we could write this:
 
 
 In most of this tutorial, we will not name the properties we want to
-prove, since they will be generally quite simple and we will not have
+prove, since they will be generally quite simple, and we will not have
 too many of them, names would not give us much information.
 
 We can copy and paste the function \CodeInline{abs} and its specification in
 a file \CodeInline{abs.c} and use Frama-C to determine if the implementation
 is correct with respect to the specification. We can start the GUI of Frama-C
-(it is also possible to use the command line interface of Frama-C but we
+(it is also possible to use the command line interface of Frama-C, but we
 will not use it during this tutorial) by using this command line:
 
 
@@ -204,7 +202,7 @@ frama-c-gui abs.c
 
 
 The window of Frama-C opens and in the panel dedicated to files and
-functions, we can select the function \texttt{abs}. At each
+functions, we can select the \texttt{abs} function. At each
 \texttt{ensures} line, we can see a blue circle, it indicates that no
 verification has been attempted for these properties.
 
@@ -219,7 +217,7 @@ function and ``Prove function annotations by WP'':
 
 
 We can see that blue circles become green bullets, indicating that the
-specification is indeed ensured by the program. We can also prove
+specification is indeed ensured by the program. Furthermore, we can also prove
 properties one by one, by right-clicking on them and not on the name of
 the function.
 
@@ -231,7 +229,7 @@ of runtime errors (RTE) if we do not ask it. Another plugin of Frama-C,
 called RTE, can be used to generate some ACSL annotations that can be verified
 by the other plugins. Its purpose is to add, in the program, some controls to
 ensure that the program cannot create runtime errors (integer overflow,
-invalid pointer dereferencing, 0 division, etc).
+invalid pointer dereferencing, 0 division, etc.).
 
 
 
@@ -316,9 +314,6 @@ so far.
 
 The orange color indicates that no prover could determine if the
 property is verified. There are two possibles reasons:
-
-
-
 \begin{itemize}
 \item the prover did not have the information needed to terminate the proof,
 \item the prover did not have enough time to compute the proof and
@@ -330,7 +325,7 @@ In the bottom panel, we can select the ``WP Goals'' tab, it shows the list of
 verification conditions, and for each prover the result is symbolized
 by a logo that indicates if the proof has been tried and if it
 succeeded, failed or met a timeout. Note that it
-may require to select ``All Results'' in the squared field to see all
+may require selecting ``All Results'' in the squared field to see all
 verification conditions.
 
 
@@ -379,14 +374,14 @@ the property that we want to verify.
 
 
 What does WP do using these properties? In fact, it transforms them
-into a logic formula and then asks to different provers if it is
+into a logic formula and then asks different provers if it is
 possible to satisfy this formula (to find for each variable, a value
 that can make the formula true), and it determines if the property can
 be proved. But before sending the formula to provers, WP uses a module
 called Qed, which is able to perform different simplifications about it.
-Sometimes, as this is the case for the other properties about
-\CodeInline{abs}, these simplifications are enough to determine that the
-property is true, in such a case, WP do not need the help of the
+Sometimes, as this is the case for the other properties about the
+\CodeInline{abs} function, these simplifications are enough to determine that
+the property is true, in such a case, WP do not need the help of the
 automatic solvers.
 
 
@@ -560,7 +555,7 @@ the call \CodeInline{abs(a)} does not, since it can succeed.
 
 
 While these exercises are not absolutely necessary to read the next chapters
-of the tutorial we strongly suggest to practice them. Note that we also
+of the tutorial we strongly suggest practicing them. Note that we also
 suggest to, at least, read the fourth exercise that introduces a notation
 that can be sometimes useful.
 
@@ -569,7 +564,7 @@ that can be sometimes useful.
 \levelFourTitle{Addition}
 
 
-Write the postcondtion of the following addition function:
+Write the postcondition of the following addition function:
 
 
 \CodeBlockInput[5]{c}{ex-1-addition.c}

--- a/english/function-contract/contract.tex
+++ b/english/function-contract/contract.tex
@@ -220,13 +220,13 @@ function and ``Prove function annotations by WP'':
 
 We can see that blue circles become green bullets, indicating that the
 specification is indeed ensured by the program. We can also prove
-properties one by one by right-clicking on them and not on the name of
+properties one by one, by right-clicking on them and not on the name of
 the function.
 
 
 
-But is our code really bug free? WP gives us a way to ensure that a
-code respects a specification, but it does not directly check the absence
+But is our code really bug free? WP gives us a way to ensure that a code
+conforms to a specification, but it does not directly check the absence
 of runtime errors (RTE) if we do not ask it. Another plugin of Frama-C,
 called RTE, can be used to generate some ACSL annotations that can be verified
 by the other plugins. Its purpose is to add, in the program, some controls to
@@ -480,7 +480,7 @@ everything is validated by WP, our implementation is proved:
 
 
 We can also verify that a function that would call \CodeInline{abs}
-correctly respects the required precondition:
+conforms to the required precondition:
 
 
 

--- a/english/function-contract/modularity.tex
+++ b/english/function-contract/modularity.tex
@@ -116,7 +116,7 @@ is leap for February.
 \CodeBlockInput[5]{c}{ex-1-days-month.c}
 
 
-\levelFourTitle{Alpha-numeric character}
+\levelFourTitle{Alphanumeric character}
 \label{l4:contract-modularity-ex-alpha-num}
 
 

--- a/english/function-contract/well-specified.tex
+++ b/english/function-contract/well-specified.tex
@@ -74,7 +74,7 @@ false:
 
 If we ask WP to prove this function, it will accept it without any problem
 since the property we ask in precondition is necessarily false.
-However, we will not be able to give an input that respects the
+However, we will not be able to give an input that conforms to the
 precondition.
 
 

--- a/english/function-contract/well-specified.tex
+++ b/english/function-contract/well-specified.tex
@@ -74,7 +74,7 @@ false:
 
 If we ask WP to prove this function, it will accept it without any problem
 since the property we ask in precondition is necessarily false.
-However, we will not be able to give an input that conforms to the
+However, we will not be able to give an input that satisfies the
 precondition.
 
 

--- a/english/function-contract/well-specified.tex
+++ b/english/function-contract/well-specified.tex
@@ -104,11 +104,7 @@ precondition is inconsistent.
 
 Note that when the smoke tests succeed, for example if we fix the
 precondition like this:
-
-
- \image{2-smoke-success}
-
-
+\image{2-smoke-success}
 it does not necessarily mean that the precondition is consistent, just
 that the prover was unable to prove that it was inconsistent.
 
@@ -212,8 +208,8 @@ by Frama-C, we can see that in the postcondition, the pointers are enclosed into
 \image{2-old-swap}
 
 
-For the built-in \CodeInline{\textbackslash{}at}, we have to take care of this
-more explicitly. In particular,
+For the built-in \CodeInline{\textbackslash{}at} function, we have to take care
+of this more explicitly. In particular,
 the specified label must make sense with respect to the scope of the
 value. For example, in the following program, Frama-C detects that we ask
 the value of the variable \CodeInline{x} at a program point where it does
@@ -227,7 +223,7 @@ not exist:
 
 
 However, in some other cases, we only reach a proof failure since determining
-that the value does not exists at some particular label cannot be done by
+that the value does not exist at some particular label cannot be done by
 a syntactic analysis. For example, if the variable is declared but undefined
 or if we want the value of a pointed value:
 
@@ -236,7 +232,7 @@ or if we want the value of a pointed value:
 
 
 Here, it is easy to see the problem. However, the considered label is
-propagated to subexpressions. Thus, sometimes, terms that seem to be
+propagated to sub-expressions. Thus, sometimes, terms that seem to be
 innocent can have a surprising behavior if we do not keep this fact in mind.
 For example, in the following example:
 
@@ -248,12 +244,12 @@ The first assertion is proved, and while the second assertion seems to
 express the same property, it cannot be proved. Because, it in fact does not
 express the same property. The expression
 \CodeInline{\textbackslash{}at(x[*p], Pre)} must be seen as
-\CodeInline{\textbackslash{}at(x[\textbackslash{}at(*p)], Pre)} as the
-label is propagated to the subexpression \CodeInline{*p}, for which we do
+\CodeInline{\textbackslash{}at(x[\textbackslash{}at(*p)], Pre)}, since the
+label is propagated to the sub-expression \CodeInline{*p}, for which we do
 not know the value at label \CodeInline{Pre} (since it is not specified).
 
 
-For the moment, we do not need \CodeInline{\textbackslash{}at} but it can
+For the moment, we do not need \CodeInline{\textbackslash{}at}, but it can
 often be useful, if not essential, when we want to make our
 specification precise.
 
@@ -466,7 +462,7 @@ Writing a specification that is precise enough can sometimes be a bit tricky.
 Interestingly, a good way to check if a specification is precise enough is to
 write tests. And in fact, this is basically what we have done for our examples
 \CodeInline{max} and \CodeInline{swap}. We have written a first version of the
-specification and we have written some code with a call to the corresponding
+specification, and we have written some code with a call to the corresponding
 function to determine whether we could prove some properties that we expected to
 be easily provable from the contract of the function.
 
@@ -592,7 +588,7 @@ unchanged.
 
 
 
-The following functions computes the maximum of the values pointed by
+The following function computes the maximum of the values pointed by
 \CodeInline{a} and \CodeInline{b}. Write the contract of the function:
 
 
@@ -649,7 +645,7 @@ frama-c-gui your-file.c -wp -wp-rte
 
 
 Remember that ordering values is not just ensuring that resulting values
-are sorted increasing order that each pointed value must be one the original
+are sorted increasing order that each pointed value must be one of the original
 ones. All original values should still be there after the sorting operation:
 new values are a permutation of the original ones. To express this idea, one
 can rely on the set datatype. For example, this property is true:

--- a/english/introduction.tex
+++ b/english/introduction.tex
@@ -34,7 +34,7 @@
   \item Why3 1.3.1
   \item Alt-Ergo 2.3.2
   \item Coq 8.11.2 (for provided scripts, not used in the tutorial)
-  \item Z3 4.8.4 (in one example, it is not absolutely necessary to follow the course)
+  \item Z3 4.8.4 (in one example, it is not absolutely necessary to follow this book)
   \end{itemize}
   Depending on the versions used by the reader some differences could appear in
   what is proved and what is not. Some presented features are only available
@@ -52,9 +52,9 @@
 
 Despite its old age, C is still a widely used programming language.
 Indeed, no other language can pretend to be available on so many
-different (hardware and software) platforms, its low-level orientation
+(hardware and software) platforms, its low-level orientation
 and the amount of time invested in the optimization of its compilers
-allows to generate very light and efficient machine code (if the code
+allows generating very light and efficient machine code (if the code
 allows it of course), and that there are a lot of experts in C language,
 which is an important knowledge base.
 
@@ -121,7 +121,6 @@ Many thanks to Jens Gerlach for his help during the translation of this tutorial
 from French to English.
 
 Thanks, finally, to the occasional reviewers on GitHub:
-
 \begin{itemize}
   \item \externalLink{Alex Lyr}{https://github.com/AlexLyrr}
   \item \externalLink{Rafael Bachmann}{https://github.com/barafael}
@@ -135,7 +134,6 @@ Thanks, finally, to the occasional reviewers on GitHub:
   \item \externalLink{Ricardo M. Correia}{https://github.com/wizeman}
   \item \externalLink{Basile Desloges}{https://github.com/zilbuz}
 \end{itemize}
-
 for their reviews and fixes.
 
 \end{Information}

--- a/english/introduction.tex
+++ b/english/introduction.tex
@@ -116,7 +116,7 @@ notions that allows to better understand and write programs.
 \item \externalLink{Saroupille}{https://zestedesavoir.com/membres/voir/Saroupille/}
 \item \externalLink{Aabu}{https://zestedesavoir.com/membres/voir/Aabu/} (again)
 \end{itemize}
-  
+
 Many thanks to Jens Gerlach for his help during the translation of this tutorial
 from French to English.
 

--- a/english/program-proof-and-our-tool/frama-c.tex
+++ b/english/program-proof-and-our-tool/frama-c.tex
@@ -52,13 +52,13 @@ maintained by OCamlPro.
 
 
 
-Frama-C is a software developed on Linux and OSX. Its support is thus better
+Frama-C is a software developed on Linux and macOS. Its support is thus better
 on those operating system. Nevertheless, it is possible to install Frama-C
 on Windows and in theory, its use will be identical to its use on Linux.
 However:
 \begin{Warning}
 \begin{itemize}
-  \item the tutorial presents the use of Frama-C on Linux (or OSX) and
+  \item the tutorial presents the use of Frama-C on Linux (or macOS) and
     the author did not experiment the differences that could exist with Windows,
   \item in recent versions of Windows 10, a possibility is to use Windows
     Subsystem for Linux, in combination with a Xserver installed on Windows
@@ -188,12 +188,12 @@ the installation.
 
 
 
-\levelFourTitle{OSX}
+\levelFourTitle{macOS}
 
 
-On OSX, the use of Homebrew and Opam is recommended to install Frama-C.
-The author does not use OSX, so here is a shameful copy and paste of the
-installation guide of Frama-C for OSX.
+On macOS, the use of Homebrew and Opam is recommended to install Frama-C.
+The author does not use macOS, so here is a shameful copy and paste of the
+installation guide of Frama-C for macOS.
 
 
 
@@ -250,7 +250,7 @@ Necessary for Frama-C/WP:
 Currently, the best way to install Frama-C on Windows is to use the
 Windows Subsystem for Linux. Basically, once the Linux system is installed,
 one should install Opam and follow the instructions provided in the Linux
-section. To get a usable graphical user interface, a Xserver should be
+section. To get a usable graphical user interface, an X server should be
 installed on Windows.
 
 

--- a/english/program-proof-and-our-tool/frama-c.tex
+++ b/english/program-proof-and-our-tool/frama-c.tex
@@ -9,7 +9,7 @@
 Frama-C (FRAmework for Modular Analysis of C code) is a platform
 dedicated to the analysis of C programs created by the CEA LIST and
 Inria. It is based on a modular architecture allowing to use different
-plugins. The default plugins comprises different static analyses (that
+plugins. The default plugins comprise different static analyses (that
 do not execute source code), dynamic analyses (that requires code
 execution), or combining both. These plugins can collaborate together
 or not, either by communicating directly or by using the specification
@@ -26,7 +26,7 @@ properties we want to verify about our programs. These properties are
 written using code annotations in comment sections. If one has
 already used Doxygen, it is quite similar, except that we write logic
 formulas and not text. During this tutorial, we will extensively write
-ASCL code, so let us just skip this for now.
+ACSL code, so let us just skip this for now.
 
 
 
@@ -41,7 +41,7 @@ automatically, here we use automatic tools.
 
 
 We will use a SMT solver
-(\externalLink{statisfiability modulo theory}{https://fr.wikipedia.org/wiki/Satisfiability\_modulo\_theories}, we do not detail how it works). This solver is
+(\externalLink{satisfiability modulo theory}{https://fr.wikipedia.org/wiki/Satisfiability\_modulo\_theories}, we do not detail how it works). This solver is
 \externalLink{Alt-Ergo}{http://alt-ergo.ocamlpro.fr/}, that was initially developed
 by the Laboratoire de Recherche en Informatique d'Orsay, and is today
 maintained by OCamlPro.
@@ -56,13 +56,10 @@ Frama-C is a software developed on Linux and OSX. Its support is thus better
 on those operating system. Nevertheless, it is possible to install Frama-C
 on Windows and in theory, its use will be identical to its use on Linux.
 However:
-
-
-
 \begin{Warning}
 \begin{itemize}
   \item the tutorial presents the use of Frama-C on Linux (or OSX) and
-    the author did not experiment the differences that could exists with Windows,
+    the author did not experiment the differences that could exist with Windows,
   \item in recent versions of Windows 10, a possibility is to use Windows
     Subsystem for Linux, in combination with a Xserver installed on Windows
     to get GUI,
@@ -100,7 +97,7 @@ the installation.
 
 
 
-\levelFiveTitle{Via opam}
+\levelFiveTitle{Via Opam}
 
 
 
@@ -109,7 +106,7 @@ and applications.
 
 
 
-First of all, Opam must be installed (see its documentation). Then, some
+First, Opam must be installed (see its documentation). Then, some
 packages from the Linux distribution must be installed before
 installing Frama-C. On most systems, it is possible to ask Opam to install
 dependencies of the packages we want to install. For this, first install
@@ -168,14 +165,14 @@ the installation.
 
 The packages we have listed in the Opam section are required (of course,
 Opam itself is not). It requires a recent version of Ocaml and its
-compiler (including a compiler to native code). Is is also necessary to
+compiler (including a compiler to native code). It is also necessary to
 install Why3 (at least version 1.2.0), which is available either on Opam
 or on their website (\externalLink{Why3}{http://why3.lri.fr/}).
 
 
 
 After having extracted the folder available here :
-\externalLink{http://frama-c.com/download.html}{http://frama-c.com/download.html} (Source distribution).
+\externalLink{https://frama-c.com/html/get-frama-c.html}{https://frama-c.com/html/get-frama-c.html} (Source distribution).
 Navigate to the folder and then execute the command line:
 
 
@@ -201,7 +198,7 @@ installation guide of Frama-C for OSX.
 
 
 
-General Mac OS tools for OCaml:
+General macOS tools for OCaml:
 
 
 
@@ -253,7 +250,7 @@ Necessary for Frama-C/WP:
 Currently, the best way to install Frama-C on Windows is to use the
 Windows Subsystem for Linux. Basically, once the Linux system is installed,
 one should install Opam and follow the instructions provided in the Linux
-section. To get a usable graphical user interface, a X server should be
+section. To get a usable graphical user interface, a Xserver should be
 installed on Windows.
 
 
@@ -287,7 +284,7 @@ The following window should appear:
 \image{verif_install-1}
 
 
-Clicking \CodeInline{main.c} in the left side panel to select it, we can see
+Clicking \CodeInline{main.c} in the left side-panel to select it, we can see
 its content (slightly) modified, and some green bullets on different
 lines as illustrated here:
 
@@ -325,7 +322,7 @@ useful \emph{in the tutorial}. However, when we start to be interested
 in proving more complex programs, it is often possible to reach the
 limits of Alt-Ergo, which is available by default, and we would thus need
 some other provers. For basic properties, almost all solvers have the
-same capabilities, for more complex ones, each solvers has its predilection
+same capabilities, for more complex ones, each solver has its predilection
 domains.
 
 
@@ -342,7 +339,7 @@ Why3 as a backend to talk with external provers.
 
 On their website, we can find the list of
 \externalLink{supported provers}{http://why3.lri.fr/\#provers}.
-We recommend to install
+We recommend installing
 \externalLink{Z3}{https://github.com/Z3Prover/z3/wiki} which is
 developed by Microsoft Research, and
 \externalLink{CVC4}{http://cvc4.cs.stanford.edu/web/} which is developed by many
@@ -357,8 +354,8 @@ However, Why3 provers list must be updated:
 why3 config --full-config
 \end{CodeBlock}
 
-And then activated in Frama-C. In the left side panel, in the WP part,
-clic "Provers..." :
+And then activated in Frama-C. In the left-side panel, in the WP part,
+click ``Provers...'':
 
 
 \image{provers}
@@ -382,7 +379,7 @@ verifies (using typing) that the proof is actually a valid proof.
 
 Why would we need such a tool? Sometimes, the properties we want to
 prove can be too complex to be solved automatically by SMT solvers,
-typically when they requires careful inductive reasoning with precise
+typically when they require careful inductive reasoning with precise
 choices at each step. In this situation, WP allows us to generate
 verification conditions translated in Coq language, and to write the
 proof ourselves.
@@ -403,16 +400,3 @@ To learn Coq, we would recommend
 
 If one needs more information about Coq and its installation, this page
 can help: \externalLink{The Coq Proof Assistant}{https://coq.inria.fr/}.
-
-
-
-The current support of Coq is deprecated in Frama-C but is still available.
-As we provide Coq scripts that can be used, we provide these instruction
-so that this way of proving programs can be tested by users. To run Frama-C
-with Coq support, use:
-
-
-
-\begin{CodeBlock}{bash}
-  frama-c -wp-prover=native:coq
-\end{CodeBlock}

--- a/english/program-proof-and-our-tool/frama-c.tex
+++ b/english/program-proof-and-our-tool/frama-c.tex
@@ -351,7 +351,7 @@ New provers can be installed any time after the installation of Frama-C.
 However, Why3 provers list must be updated:
 
 \begin{CodeBlock}{bash}
-why3 config --full-config
+why3 config detect
 \end{CodeBlock}
 
 And then activated in Frama-C. In the left-side panel, in the WP part,

--- a/english/program-proof-and-our-tool/program-proof.tex
+++ b/english/program-proof-and-our-tool/program-proof.tex
@@ -97,7 +97,7 @@ we can classify into three categories:
 Each of these categories can affect the safety and/or the security of our
 programs, but these two notions are not equivalent. Loosely speaking,
 in security a malicious entity that can attack the system, while in safety, we
-want to verify when used in a conform way, the system well behaves. Thus, safety
+want to verify when used in a correct way, the system well behaves. Thus, safety
 is a first before we can get security\footnote{Depending on the field you are
   working in, the term ``safety'' may have a very different sense. Namely, a
   \textit{safe} system must be a system that can never cause injuries to human

--- a/english/program-proof-and-our-tool/program-proof.tex
+++ b/english/program-proof-and-our-tool/program-proof.tex
@@ -38,7 +38,7 @@ choose good tests.
 
 
 The goal of program proof is to ensure that, for any input provided to a
-given program, if it respects the specification, then the program will
+given program, if it conforms to the specification, then the program will
 only well-behave. However, since we cannot test everything, we will
 formally, mathematically, establish a proof that our software can only
 exhibit specified behaviors, and that runtime-errors are not part of

--- a/english/program-proof-and-our-tool/program-proof.tex
+++ b/english/program-proof-and-our-tool/program-proof.tex
@@ -107,7 +107,7 @@ is a first before we can get security\footnote{Depending on the field you are
 
 
 In this tutorial, we will show how we can prove that implementations
-of our programs do not contains bugs related to the two first categories
+of our programs do not contain bugs related to the two first categories
 defined above, meaning that they conform to:
 
 \begin{itemize}

--- a/english/program-proof-and-our-tool/program-proof.tex
+++ b/english/program-proof-and-our-tool/program-proof.tex
@@ -4,13 +4,10 @@
 It is often difficult to ensure that our programs have only correct
 behaviors. Moreover, it is already complex to establish good criteria
 that make us confident enough to say that a program works correctly:
-
-
-
 \begin{itemize}
 \item
   beginners simply ``try'' to use their programs and consider that
-  these programs work if they do not crash (which is not a really good
+  these programs work if they do not crash (which is not an excellent
   indicator in C language),
 \item
   more advanced developers establish some test cases for which they know
@@ -68,13 +65,11 @@ exist''. And, if this sentence is quite true, it is a bit misunderstood.
 
 First, we do not really define what we mean by ``bug-free''. Creating
 software always relies at least on two steps: we establish a specification
-of what we expect from the program and then we produce the source code of
+of what we expect from the program, and then we produce the source code of
 the program that must respect this specification. Moreover, we can add that
 our programming language itself defines what is the correct way to use it.
 On each of these aspects, an error can lead to the introduction of bugs that
 we can classify into three categories:
-
-
 \begin{itemize}
 \item the program is not correct, or does not have a defined behavior,
       according to the language specification (for example, a program
@@ -109,7 +104,6 @@ is a first before we can get security\footnote{Depending on the field you are
 In this tutorial, we will show how we can prove that implementations
 of our programs do not contain bugs related to the two first categories
 defined above, meaning that they conform to:
-
 \begin{itemize}
 \item the specification of our language,
 \item the specification that we have provided for them.
@@ -193,9 +187,9 @@ a chronometer could be the one presented here:
 We have a model of the behavior of our chronometer with the different
 states it can reach according to the different actions we can perform.
 However, we have not modeled how these states are implemented in the
-program (is this a C enumeration? a particular program point in the
-source code?), nor how the computation of the elapsed time is done (a single
-variable? multiple ones?). It would then be difficult to specify
+program (Is this a C enumeration? A particular program point in the
+source code?), nor how the computation of the elapsed time is done (A single
+variable? Multiple ones?). It would then be difficult to specify
 properties about our program. We could add some information:
 
 
@@ -207,7 +201,7 @@ properties about our program. We could add some information:
 
 
 
-Which gives us a more concrete model but that is still not precise
+Which gives us a more concrete model, but that is still not precise
 enough to ask interesting questions like: ``is it possible for the program
 to continue updating the time variable while the chronometer is on the Stopped
 state?'', as we do not model how the time measurement is updated by the
@@ -239,7 +233,7 @@ pleasant to read\textsuperscript{\ref{footnote:1}}.
 When we create an abstraction of a system, we approximate it, in order
 to limit the knowledge we have about it and make our reasoning easier. A
 constraint we must respect, if we want our analysis to be correct, is to
-never under-approximate behaviors: we would risk to remove a behavior
+never under-approximate behaviors: we would risk removing a behavior
 that contains an error (and thus miss it during the analysis). However,
 when we over-approximate the behaviors of the program, we can add
 behaviors that cannot happen, and if we add too many of them, we could
@@ -257,7 +251,7 @@ complex subtleties (which makes this model concrete).
 \footnotetext[1]{\label{footnote:1}
   There also exists formal methods which are
   interested in understanding how executable machine code work, for
-  example in order to understand what malwares do or to detect security
+  example in order to understand what malware does or to detect security
   breaches introduced during compilation.}
 
 
@@ -269,9 +263,6 @@ Hoare logic is a program formalization method proposed by
 \externalLink{Tony Hoare}{https://en.wikipedia.org/wiki/Charles_Antony_Richard_Hoare}
 in 1969 in a paper entitled \emph{An Axiomatic Basis for Computer
 Programming}. This method defines:
-
-
-
 \begin{itemize}
 \item   axioms, that are properties we admit, such as ``the skip action does
   not change the program state'',
@@ -315,7 +306,7 @@ When we do nothing, the postcondition is the precondition.
 
 
 Along this tutorial, we will present the semantics of different program
-constructs (conditional blocks, loops, etc) using Hoare logic. So,
+constructs (conditional blocks, loops, etc.) using Hoare logic. So,
 let us skip these details now since we will work on it later. It is
 not necessary to memorize these notions nor to understand all the
 theoretical background, but it is still useful to have some ideas about
@@ -337,12 +328,12 @@ The weakest precondition calculus is a form of predicate transform
 semantics proposed by Dijkstra in 1975 in \emph{Guarded commands,
 non-determinacy and formal derivation of programs}.
 
-This title can appear complex but actually the content of the article is in
+This title can appear complex, but actually the content of the article is in
 fact quite simple. We have seen before that Hoare logic gives us rules that
 explain the behavior of the different actions of a program, but it does not say
 how to apply these rules to establish a complete proof of the program.
 
-Dijkstra reformulate the Hoare logic by explaining, in the triple
+Dijkstra reformulates the Hoare logic by explaining, in the triple
 $\{P\}\ C\ \{Q\}$, how the instruction, or the block of instructions,
 $C$ transforms the predicate $P$ in $Q$. This kind of reasoning is
 called \emph{forward-reasoning}. We calculate from the precondition and

--- a/english/proof-methodologies.tex
+++ b/english/proof-methodologies.tex
@@ -8,7 +8,7 @@ verification, the expected level of confidence and the kind of formalization
 %% \begin{levelTwo}
 %%   {Data-structure API}
 %%   {data-structure-api}
-%% \end{levelTwo}  
+%% \end{levelTwo}
 
 \begin{levelTwo}
   {Absence of runtime errors: Minimal contracts}
@@ -39,7 +39,7 @@ guide the prover, or write ghost code with the right invariant that
 allows to make a part of the reasoning by ourselves when it is too hard
 for SMT solvers.
 
-With some experience, we can read the content of the proof obligations or
+With some experience, we can read the content of the verification condition or
 try to perform the proof with the Coq interactive prover to see whether
 the proof seems to be possible. Sometimes, the prover just needs more
 time, in such a case, we can (sometimes a lot) augment the timeout value.

--- a/english/proof-methodologies/lemma-functions.tex
+++ b/english/proof-methodologies/lemma-functions.tex
@@ -281,7 +281,7 @@ assertion from the precondition:
 Of course, there exists some index \CodeInline{n} such that \CodeInline{in[n]}
 is \CodeInline{v}, else the number of occurrences of this value would be $0$.
 But, instead of just proving that such an index exists, let us directly find
-some index that respects the constraints on \CodeInline{n} by using a lemma
+some index that satisfies the constraints on \CodeInline{n} by using a lemma
 function that returns it:
 
 
@@ -299,7 +299,7 @@ a value \CodeInline{v}.
 
 
 
-We prove that the second behavior respects the postcondition by showing that it
+We prove that the second behavior ensures the postcondition by showing that it
 leads to a contradiction. If there is no cell of value \CodeInline{v}, then
 the number of occurrences of \CodeInline{v} is 0, this is expressed by the
 second invariant that shows that as we have not met any \CodeInline{v} from
@@ -454,7 +454,7 @@ same), and to establish our premises. Indeed, if we have a look at the contract
 of \CodeInline{assign\_array}, we see that it assigns the array (which
 guarantees the creation of a new memory label) and in postcondition, it ensures
 that the content of the array, between the pre and the postcondition (thus, when
-we call it: \CodeInline{L1} and \CodeInline{L2}) respects the premise of our
+we call it: \CodeInline{L1} and \CodeInline{L2}) verifies the premise of our
 lemma (which we repeat on line 15, by adding an assertion). Then we use our
 \CodeInline{shift\_ptr} macro (that will later contain the proof carrying code),
 and we then expect to be able to prove the postcondition of our lemma (line 19).
@@ -660,7 +660,7 @@ as else, we do not have anything to count):
 
 
 which is enough to ensure that the \CodeInline{insertion\_sort} function
-respects its specification as long as we finish the proof of the function
+conforms to its specification as long as we finish the proof of the function
 \CodeInline{insert}. This second function makes a more complex action. Let us
 depart from this annotated version:
 

--- a/english/proof-methodologies/lemma-functions.tex
+++ b/english/proof-methodologies/lemma-functions.tex
@@ -34,7 +34,7 @@ induction. What is this sorcery?!
 
 In fact, it is quite simple. When we prove a loop invariant by induction using
 SMT solvers, they do not have to perform the reasoning by induction themselves.
-The job of splitting the proof into two subproofs, one for the establishment of
+The job of splitting the proof into two sub-proofs, one for the establishment of
 the invariant (the base case of the proof), and one for the preservation (the
 induction case) is performed by the verification condition generator. So when
 the verification conditions are transmitted to the SMT solvers, this work is not
@@ -208,26 +208,14 @@ precondition for the call to \CodeInline{bsearch}).
 
 
 As we explained, when universally quantified variables are bounded to both
-conclusion and premises, they must be parameters, and it is the case here for
+conclusion and premises. They must be parameters, and it is the case here for
 the variables \CodeInline{arr} and \CodeInline{len}. Whereas the quantified
 variable that are used in the predicates:
-
-
-
 \CodeBlockInput[4][8]{c}{lemma-function-1-2.c}
-
-
-
 as they are only bound to respectively the premise and the conclusion remain
 universally quantified (even if it is hidden by the predicate). We could for
 example have written the contract like this:
-
-
-
 \CodeBlockInput[15][32]{c}{lemma-function-1-3.c}
-
-
-
 where we perfectly see that variables are still universally quantified. However,
 we are not forced to maintain them universally quantified, and we could
 perfectly translate them into parameters (provided that the conclusion we want
@@ -240,7 +228,7 @@ to get from the premises still makes sense). Let us for example translate the
 
 
 
-Which is also perfectly fine and we could for example use this function to
+Which is also perfectly fine, and we could for example use this function to
 deduce some properties about the content of the array. Note that here, we use a
 call to the previous lemma function to make the proof easier. We even can go
 further by transferring the ``premise of our conclusion'' as another premise of
@@ -306,7 +294,7 @@ second invariant that shows that as we have not met any \CodeInline{v} from
 the beginning of the loop,
 the number of occurrences is 0. However, the precondition of the
 function states that the number of occurrences is more than $0$ which leads to
-a contradiction that we model model by an assertion of false (note that this is
+a contradiction that we model by an assertion of false (note that this is
 not necessary, we explicitly write it for our explanation) which means here that
 this path is infeasible.
 
@@ -322,7 +310,7 @@ allows our assertion to be validated:
 
 
 The use of lemma functions makes reasoning by induction feasible for lemmas
-without the need of interactive proof. Furthermore, the triggerring of lemmas
+without the need of interactive proof. Furthermore, triggering lemmas
 becomes more predictable as we instantiate them by hand. However, while lemmas
 can consider multiple labels:
 
@@ -349,7 +337,7 @@ do when we need such a construct.
 When we have to deal with multiple labels, the idea is to directly ``inject''
 the proof carrying code at the place where it is needed exactly as we did at the
 beginning of the section. However, we do not want to write this code by hand
-everytime we need such a proof, so let us use macros to do it.
+every time we need such a proof, so let us use macros to do it.
 
 
 
@@ -378,7 +366,7 @@ directly injected in the function \CodeInline{bsearch\_callee}.
 
 
 So in fact, we use the macro to generate the code we previously wrote. In this
-case, it is not really interesting as a function call allows us to make things
+case, it is not interesting, since a function call allows us to make things
 more modular. So let us study a case where we do not have any other choice than
 using a macro.
 
@@ -446,8 +434,8 @@ Let us decompose this code, starting from the context function. In input, we
 receive all the variables of the lemma. We also state some properties about the
 bounds of the integer values we consider, basically these should be requirements
 that are not related to memory states, or related to the first one. Then, we
-introduce the label
-\CodeInline{L1} and we call the function \CodeInline{assign\_array} that leads
+introduce the label \CodeInline{L1},
+and we call the function \CodeInline{assign\_array} that leads
 us to the label \CodeInline{L2}. The role of this call is to ensure that WP will
 create a new memory label (thus, it will not consider that the memory is the
 same), and to establish our premises. Indeed, if we have a look at the contract
@@ -472,8 +460,8 @@ the conclusion (line 19) from the premise (line 15). Now let us write the macro.
 
 
 We will not detail this code which is quite similar to what we have written in
-the beginning of this section. the only small subtlety is the assert that helps
-the SMT solvers to relate the memory locations between \CodeInline{L1} and
+the beginning of this section. The only small subtlety is the assertion that
+helps the SMT solvers to relate the memory locations between \CodeInline{L1} and
 \CodeInline{L2} together on lines 8--9. With this macro, we can see that the
 assertion at the end of the function \CodeInline{context\_to\_prove\_shift\_ptr}
 is correctly, proved. Thus, we expect the macro to help the provers to get a
@@ -509,7 +497,7 @@ we have to do the proof again.
 
 All of this can make the proof context bigger, and harder to use for SMT solvers.
 There are other limitations to this technique and the careful reader might have
-notice them. Let us now talk about it.
+noticed them. Let us now talk about it.
 
 
 
@@ -560,13 +548,13 @@ an invariant that would allow us to prove this property.
 The other limitation is related to lemma macros and what we already mentioned
 in the previous part about assertions. By adding too many assertions, the proof
 context can become too big and complex, thus hard to manipulate for SMT
-solvers. Using lemma macros that can generate quite a lot code and annotations
+solvers. Using lemma macros that can generate quite a lot of code and annotations
 can lead to bigger proof contexts, thus it should be used with care.
 
 
 Finally, depending on the property to prove, it can be hard to find a proof
 carrying code. Indeed, proof assistants like Coq have been designed to be able
-to express proofs even for complex properties, mainly relying on an high level
+to express proofs even for complex properties, mainly relying on a high level
 view of our problems, while C has been designed to write programs, and with
 really detailed low level view of our problems. Thus, it can be sometimes
 difficult to write a C program to handle some properties and even more to find
@@ -585,11 +573,9 @@ reader can refer to the version proposed in the book ACSL by Example which can
 be adapted with a similar technique and is easier to prove). Thus, in
 this example, we push the solvers to their limit because of big proof contexts.
 With this example, depending on how powerful the machine is, we might need to
-increase the proof timeout to 120 seconds (which is already quite long for a
+increase the proof timeout to 120 seconds (which is already quite long for an
 SMT solver). In this example, we will illustrate three actual usage of ghost
 code that we have seen so far:
-
-
 \begin{itemize}
 \item directly writing code to build a proof,
 \item writing (and using) lemma functions,
@@ -624,9 +610,9 @@ function, we made use of three assertions:
 
 
 The first one makes sure that the part of the array where we just inserted a
-value is a permutation of the same range of values before the call to
-\CodeInline{insert}, as this is the postcondition of the function, it is not
-necessary but let us keep it for illustration. The last assertion is the
+value is a permutation of the same range of values before the call to the
+\CodeInline{insert} function, as this is the postcondition of the function, it
+is not necessary but let us keep it for illustration. The last assertion is the
 property we want to prove in order to get enough knowledge to use the lemma that
 states that permutation is transitive (and show that after the block of the loop
 since our array is a permutation of the array at the beginning, which is itself
@@ -640,7 +626,7 @@ want to use this knowledge to show that the number of occurrences of the values
 is unchanged. Here we could use a combination of lemma functions and macros to
 prove that the complete range is a permutation (as we will do for the other
 function) however, directly writing the code is here a bit simpler (requires
-less proofs, as we will see later) so let us directly write the code that will
+fewer proofs, as we will see later) so let us directly write the code that will
 create the proof of our property.
 
 
@@ -654,15 +640,11 @@ to \CodeInline{end} with an invariant \CodeInline{permutation{L,PI}(a, beg, j)},
 let us continue the occurrences counting for the rest of our array, knowing that
 the second part is unchanged (when \CodeInline{i+1} is lower than \CodeInline{end}
 as else, we do not have anything to count):
-
-
 \CodeBlockInput[275][291]{c}{insert-sort-auto-proved.c}
-
-
 which is enough to ensure that the \CodeInline{insertion\_sort} function
-conforms to its specification as long as we finish the proof of the function
-\CodeInline{insert}. This second function makes a more complex action. Let us
-depart from this annotated version:
+conforms to its specification as long as we finish the proof of the
+\CodeInline{insert} function. This second function makes a more complex action.
+Let us depart from this annotated version:
 
 
 \CodeBlockInput[50][84]{c}{insert-sort-auto.c}
@@ -675,7 +657,6 @@ for \CodeInline{insertion\_sort} is not so easy here. Indeed, the second part
 of the array has been rotated which makes the properties slightly more
 complex. So, let us show that we can split the array at the position where
 we insert into two parts, in which we respectively show that:
-
 \begin{itemize}
 \item for the first part, since it is unchanged, for any $v$, the number of
   occurrences did not change either,
@@ -755,7 +736,7 @@ lemma macro:
 
 
 Which almost corresponds to what we have written previously in the
-\CodeInline{insert\_sort} function and we can use the macro where it is needed
+\CodeInline{insert\_sort} function, and we can use the macro where it is needed
 in the \CodeInline{insert} function.
 
 
@@ -818,8 +799,8 @@ We can use the macro in our program:
 
 However, we have to show that the considered range at label \CodeInline{Pre} can
 be split at \CodeInline{last}. For this, we use another variant of the split
-function, that shows that any subrange can be split before the last element (if
-it is non empty):
+function, that shows that any sub-range can be split before the last element (if
+it is non-empty):
 
 
 
@@ -936,7 +917,7 @@ number of occurrences of \CodeInline{v} is positive. Note that you will
 probably need to use \CodeInline{occ\_monotonic}.
 
 
-Finally the function \CodeInline{occ\_pos\_exists} should translate the contract
+Finally, the function \CodeInline{occ\_pos\_exists} should translate the contract
 of the previous function using an existentially quantified variable, and use the
 previous function to obtain the proof for free.
 

--- a/english/proof-methodologies/lemma-functions.tex
+++ b/english/proof-methodologies/lemma-functions.tex
@@ -442,7 +442,7 @@ same), and to establish our premises. Indeed, if we have a look at the contract
 of \CodeInline{assign\_array}, we see that it assigns the array (which
 guarantees the creation of a new memory label) and in postcondition, it ensures
 that the content of the array, between the pre and the postcondition (thus, when
-we call it: \CodeInline{L1} and \CodeInline{L2}) verifies the premise of our
+we call it: \CodeInline{L1} and \CodeInline{L2}) satisfies the premise of our
 lemma (which we repeat on line 15, by adding an assertion). Then we use our
 \CodeInline{shift\_ptr} macro (that will later contain the proof carrying code),
 and we then expect to be able to prove the postcondition of our lemma (line 19).

--- a/english/proof-methodologies/minimal-contracts.tex
+++ b/english/proof-methodologies/minimal-contracts.tex
@@ -1,7 +1,7 @@
-We have seen that program proof allows to verify two main aspects of program
+We have seen that program proof allows verifying two main aspects of program
 correctness: first that programs do not contain runtime errors, second that
 programs correctly implement their specification. However, it is sometimes hard
-to guarantee the later, and the former is already an interesting step for
+to guarantee the latter, and the former is already an interesting step for
 program correctness.
 
 Indeed, runtime errors often cause the presence of so-called ``undefined
@@ -18,7 +18,7 @@ The minimal contracts approach is guided by the RTE plugin. Basically, the idea
 is to generate the assertions related to absence of runtime errors for all the
 functions of a module or a project and to write the minimal set of (correct)
 contracts that are sufficient to prove that the runtime errors cannot happen.
-Most of the time, we need far less lines of specification that what is usually
+Most of the time, we need far fewer lines of specification that what is usually
 required to prove the functional correctness of the program.
 
 
@@ -114,9 +114,7 @@ a look at the assertion that RTE asks us to verify:
 \CodeBlockInput[30][39]{c}{search-4.c}
 
 
-Thus we have to verify that:
-
-
+Thus, we have to verify that:
 \begin{itemize}
 \item the pointer we received from \CodeInline{search} is valid,
 \item \CodeInline{*p + 1} does not overflow,
@@ -152,7 +150,7 @@ with a relatively low-cost approach.
 
 However, as we have seen, when we use a function it can change the knowledge
 we need about its behavior, requiring to make the contract richer and richer.
-Thus we can progressively reach a state where we basically proved the functional
+Thus, we can progressively reach a state where we basically proved the functional
 correctness of the function.
 
 

--- a/english/proof-methodologies/triggering-lemmas.tex
+++ b/english/proof-methodologies/triggering-lemmas.tex
@@ -81,7 +81,7 @@ what is important, the other properties can just be ignored in our case):
 
 
 Here, we can see that for the proof of the second assertion, WP has collected
-and added the first assertion to the assumptions. Thus WP considers that SMT
+and added the first assertion to the assumptions. Thus, WP considers that SMT
 solvers can assume this assertion. That means that they can rely on it, but also
 that it should be proved to be sure that the current verification condition is
 verified.
@@ -100,7 +100,7 @@ verification condition.
 \image{context_e1p_a2}
 
 
-Now let us modify the example a little bit in order to illustrate how assertions
+Now let us modify the example a bit in order to illustrate how assertions
 can change the way to prove a program. For example, let us first modify the
 different memory locations (doubling each value) and check that the resulting
 triangle is a right triangle.
@@ -219,7 +219,7 @@ condition (again we have removed what is not useful for our explanations):
 
 Thus, the SMT solver seems to be unable to use one of the two axioms of our
 definition: either it cannot show that after the call to \CodeInline{g(y)},
-\CodeInline{P(x)} is still true, or it can and thus it cannot show that it
+\CodeInline{P(x)} is still true, or it can, and thus it cannot show that it
 implies that \CodeInline{Q(x)} is true. Let us try to add an assertion so that
 we verify that we can prove \CodeInline{P(x)} after the call:
 
@@ -267,7 +267,7 @@ definitions. This time, we will prove the insertion sort function:
 
 The \CodeInline{insertion\_sort} function visits each value, from the beginning
 of the array, to the end. For each value $v$, it is inserted (using the
-function \CodeInline{insert}) at the right place in the range of the already
+\CodeInline{insert} function) at the right place in the range of the already
 sorted values (at the beginning of the array), by shifting them until it meets
 a value that is smaller than $v$ or the first cell of the array.
 
@@ -316,7 +316,7 @@ Then, we need to provide a suitable invariant to the loop of the
 previously defined permutation predicate, we are in trouble.
 Indeed, our inductive definition of the permutation specifies three cases: a
 range is permutation of itself, or two (and only two) values have been swapped,
-or the permutation is transitive. But none of this cases can be applied to our
+or the permutation is transitive. But none of these cases can be applied to our
 \CodeInline{insert} function, since the shifted range is not obtained by
 successively exchanging values, and that the other cases obviously do not apply
 here.
@@ -347,11 +347,11 @@ And it is of course also possible for our shifted range.
 
 
 
-Let us determine what are the required lemmas by first considering the function
-\CodeInline{insert\_sort}. The only property that is not proved is the invariant
-of the loop that expresses the fact that the array is a permutation of the
-original array. How can we deduce it? (We will consider the proofs of the lemmas
-later).
+Let us determine what are the required lemmas by first considering the
+\CodeInline{insert\_sort} function. The only property that is not proved is the
+invariant of the loop that expresses the fact that the array is a permutation of
+the original array. How can we deduce it? (We will consider the proofs of the
+lemmas later).
 
 
 
@@ -384,7 +384,7 @@ not:
 
 
 So we need a first lemma for this property. Let us define two predicates
-\CodeInline{shifted} and \CodeInline{unchanged}, the later being used to
+\CodeInline{shifted} and \CodeInline{unchanged}, the latter being used to
 define the former (we will see why later) and express that an unchanged
 range is a permutation.
 
@@ -458,19 +458,17 @@ unchanged, so this is a permutation. We have a lemma for this, but we also have
 to state that the values are unchanged as an invariant of the loop. The second
 part of the array is a permutation because we rotate the elements, we need a
 lemma to express this, and to state at least that the element are shifted by the
-loop as an invariant. Finally the union of the two permutations is a
+loop as an invariant. Finally, the union of the two permutations is a
 permutation, and we also have a lemma for this.
 
 
 
 So first, we can give a suitable invariant for the permutation:
-
 \begin{itemize}
 \item we provide the bounds of \CodeInline{i}
 \item we state that the first part is left unchanged
 \item we state that the last part is shifted to the left
 \end{itemize}
-
 as well as some assertions that we want to be verified:
 \begin{itemize}
 \item first in order to trigger \CodeInline{unchanged\_permutation}, we place
@@ -479,7 +477,7 @@ as well as some assertions that we want to be verified:
 \item the second one that asserts that the first part of the array is a
   permutation of the original one, and is used in combination  with ...
 \item the third one that asserts that the second part of the array is a
-  permutation of the original one (which allows to trigger
+  permutation of the original one (which allows triggering
   \CodeInline{union\_permutation} and prove the postcondition).
 \end{itemize}
 
@@ -515,7 +513,7 @@ elements:
 \CodeBlockInput[60][64]{c}{insert_sort-proved.c}
 \CodeBlockInput[75][78]{c}{insert_sort-proved.c}
 
-We also have to help a little bit the provers to show that the range is
+We also have to help a bit the provers to show that the range is
 sorted after the insertion. For this, we provide a new invariant to show
 that the shifted values are greater than the value to insert, and then
 we add some assertions to show that the array is sorted before the
@@ -549,7 +547,7 @@ To prove \CodeInline{l\_occurrences\_union}, we reason by induction on the size
 of the second part of the array, the basic case is trivial: if the size is 0, we
 immediately have the equality since \CodeInline{split == to}. So now, we have
 to prove that if it is true for a range of size $i$, it is true for a range of
-size $i+1$. As we know that it is true until $i$ by our induction hypothese, we
+size $i+1$. As we know that it is true until $i$ by our induction hypotheses, we
 simply analyze the different cases for the last element of the range: either this
 element is the one we count or not, and it adds the same value on both sides of
 the equality.
@@ -562,9 +560,9 @@ same.
 
 
 The property \CodeInline{unchanged\_is\_permutation} is proved by SMT solvers
-thank to the fact that we have expressed it using \CodeInline{shifted}, then the
+thanks to the fact that we have expressed it using \CodeInline{shifted}, then the
 solver can immediately instantiate the previous lemma. If it is not the case
-(depending on the version of the prover), the proof is done by instanciating
+(depending on the version of the prover), the proof is done by instantiating
 \CodeInline{shifted\_maintains\_occ} with a value of 0 for the shift property.
 
 
@@ -580,7 +578,7 @@ and that the number of occurrences in \CodeInline{beg .. beg+1} at
 case analysis (and using the fact that the values equal).
 
 
-For \CodeInline{union\_permutation}, we intantiate the lemma
+For \CodeInline{union\_permutation}, we instantiate the lemma
 \CodeInline{l\_occurrences\_union}. Finally, the lemma
 \CodeInline{transitive\_permutation} is automatically proved by SMT solvers
 thanks to the transitivity of equality.
@@ -593,10 +591,10 @@ There is no perfect guideline on when we should use assertions or not. Most of
 the time we use them to first understand why some proof fails at some point by
 expressing properties that we expect to be true at some program point. Moreover,
 most of the time, the verification conditions are too long and complex to be read
-directly and we somewhat have to keep in mind the different lemmas we have
+directly, and we somewhat have to keep in mind the different lemmas we have
 already expressed and to determine whether some deduction requires the use of
 a lemma that we already expressed, or if it requires to reason by induction on
-some property or value such that SMT solvers cannot make this deduction and thus
+some property or value such that SMT solvers cannot make this deduction, and thus
 we might need to add another lemma.
 
 
@@ -706,8 +704,7 @@ been modified in this part of the array, and same for the cells that follow the
 modified cell.
 
 
-Thus we need two lemmas:
-
+Thus, we need two lemmas:
 \begin{itemize}
 \item \CodeInline{sum\_separable} should express that we can split an array into
   two subparts, count in each of them and sum the results to get the sum of the

--- a/english/statements/basic.tex
+++ b/english/statements/basic.tex
@@ -42,19 +42,13 @@ x = 43 * c ;
 In order to compute the precondition of the assignment we have replaced
 each occurrence of $x$ in the postcondition by the assigned value
 $E = 43*c$. If our program were of the form:
-
-
-
 \begin{CodeBlock}{c}
 int c = 6 ;
 // { 43*c = 258 }
 x = 43 * c ;
 // { x = 258 }
 \end{CodeBlock}
-
-
-
-we could submit the formula " $43*6 = 258$ " to our automatic prover
+we could submit the formula $43*6 = 258$ to our automatic prover
 in order to determine whether it is really valid. The answer would of
 course be ``yes'' because the property is easy to verify. If we had,
 however, given the value 7 to the variable \texttt{c} the prover's reply
@@ -76,18 +70,12 @@ come into play.
 
 
 For example, we can ask Frama-C to verify the following line:
-
-
-
 \begin{CodeBlock}{c}
 int a = 42;
 //@ assert a == 42;
 \end{CodeBlock}
-
-
-
 which is, of course, directly proven by Qed, since it is a simple
-applications of the assignment rule.
+application of the assignment rule.
 
 
 
@@ -124,7 +112,7 @@ this simple Hoare triple:
 
 This Hoare triple is correct, since \CodeInline{p} and \CodeInline{q} are in
 alias, modifying \CodeInline{*p} also modifies \CodeInline{*q}, thus both these
-expression evaluate to $1$ and the postcondition is true. However let us apply
+expressions evaluate to $1$ and the postcondition is true. However, let us apply
 the weakest precondition calculus from the postcondition:
 
 
@@ -140,7 +128,7 @@ We get the weakest precondition: \CodeInline{1 + *q == 2}, and thus we could
 deduce that the weakest precondition is \CodeInline{*q == 1}, which is true, but
 does not allow us to conclude that the program is correct, since in our formula
 we do not have anything that models that \CodeInline{p == q ==> *q == 1}. In
-fact, here, we would like to be able to compute a weakest precondition like:
+fact, here, we would like to be able to compute the weakest precondition like:
 
 
 
@@ -182,7 +170,7 @@ a function, the memory context can be populated with the memory locations for
 which a value is known to be defined.
 
 
-Now, we can change a little bit the weakest precondition calculus for assignment
+Now, we can change a bit the weakest precondition calculus for assignment
 of pointed memory location. For this, we consider that we have an implicit
 variable $M$ that models the memory, and we define the assignment of a memory
 location as an update of the memory such that now the corresponding pointer points
@@ -191,10 +179,8 @@ $$wp(*x = E, Q) := Q[M \leftarrow M[x \mapsto E]]$$
 
 
 And evaluating a pointed value $*x$ in a formula now requires us to use the
-get operator to ask the right value. Thus we can for example compute the weakest
+get operator to ask the right value. Thus, we can for example compute the weakest
 precondition of our previous program:
-
-
 \begin{tabular}{lll}
   $wp(*p = 1, *p + *q = 2)$
   & $= (*p + *q = 2)[M \leftarrow M[p \mapsto 1]]$ & (1)\\
@@ -205,8 +191,6 @@ precondition of our previous program:
   & $= (\texttt{if}\ q = p\ \texttt{then}\ 1+1 = 2\ \texttt{else}\ 1+M[q] = 2)$ & (6)\\
   & $= (q = p \vee M[q] = 1)$ & (7)
 \end{tabular}
-
-
 \begin{enumerate}
 \item we have to apply the rule of assignment for pointers, but for this we need
   to introduce $M$,
@@ -481,7 +465,7 @@ strengthen the postcondition with an assertion that at the end
 \CodeInline{res}, the result, is between 0 and 90. The calculation of the
 weakest precondition of this property together with the assignment
 \CodeInline{res = 10 * a} yields a weaker precondition
-\CodeInline{1 <= a <= 9} and we know that
+\CodeInline{1 <= a <= 9}, and we know that
 \CodeInline{2 <= a <= 8} gives us the desired
 guarantee.
 
@@ -617,11 +601,11 @@ $Q \Rightarrow Q \wedge R$ hold.
 
 
 
-\levelThreeTitle{Exercices}
+\levelThreeTitle{Exercises}
 
 
 
-\levelFourTitle{A serie of assignment}
+\levelFourTitle{A series of assignment}
 
 
 Compute by hand the weakest precondition of the following program:
@@ -650,10 +634,10 @@ right rule.
 \levelFourTitle{Empty ``then'' branch in conditional}
 
 
-We previously shown that when a conditional structure has an empty ``else''
+We have previously shown that when a conditional structure has an empty ``else''
 branch, that means that the conjunction of the precondition and the negation
 of the condition must be enough to verify the postcondition of the complete
-condtional structure.
+conditional structure.
 For both of the following question, we only need the inference rules and
 no WP calculus.
 
@@ -697,7 +681,7 @@ if(cond1){
 Show that on those two source code, the weakest precondition calculus
 generates an equivalent weakest precondition for equivalent for any code
 in the ``then'' block. Note that we assume the conditions to be pure
-expressions (without side-effects).
+expressions (without side effects).
 
 
 

--- a/english/statements/basic.tex
+++ b/english/statements/basic.tex
@@ -69,7 +69,7 @@ $$\dfrac{}{\{Q[x \leftarrow E] \}\quad x = E \quad\{ Q \}}$$
 
 We note that there is no premise to verify. Does this mean that the
 triple is necessarily true? Yes. However, it does not mean that the
-precondition is respected by the program to which the assignment belongs
+precondition is satisfied by the program to which the assignment belongs
 or that the precondition is at all possible. Here the automatic provers
 come into play.
 

--- a/english/statements/introduction.tex
+++ b/english/statements/introduction.tex
@@ -12,8 +12,7 @@
 \end{Information}
 
 
-We will associate with every C programming construct
-
+We will associate with every C programming construct:
 \begin{itemize}
 \item the corresponding inference rule together,
 \item its governing rule from the weakest precondition calculus and

--- a/english/statements/loops-examples.tex
+++ b/english/statements/loops-examples.tex
@@ -46,7 +46,7 @@ ACSL, the keywords \CodeInline{\textbackslash{}forall} ($\forall$) and
 \CodeInline{\textbackslash{}exists} ($\exists$), the universal logic
 quantifiers. The first one allows to state that for any element, some
 property is true, the second one allows to say that there exists some
-element such that the property is true. If we comment a little bit the
+element such that the property is true. If we comment a bit the
 corresponding lines in our specification, we can read them this way:
 
 
@@ -64,7 +64,7 @@ corresponding lines in our specification, we can read them this way:
 
 
 
-If we want to summarize the use of these keyword, we would say that on a
+If we want to summarize the use of these keywords, we would say that on a
 range of values, a property is true, either about at least one of them
 or about all of them. A common scheme is to constrain this set using
 another property (here: \CodeInline{0 <= off < length}) and to prove the
@@ -90,9 +90,9 @@ With \CodeInline{\textbackslash{}exists type a ; p(a) \&\& q(a)}, the
 constraint \texttt{p} is followed by a conjunction. We say there exists
 an element such that it satisfies the property \texttt{p} at the same
 time it also satisfies \texttt{q}. If we use an implication, as we do
-for ``forall'', such an expression will always be true if \texttt{p} is
-not a tautology! Why? Is there an ``a'' such that p(a) implies q(a)? Let
-us take any ``a'' such that p(a) is false, then the implication is true.
+for \CodeInline{\textbackslash{}forall}, such an expression will always be true
+if \texttt{p} is not a tautology! Why? Is there an ``a'' such that p(a) implies
+q(a)? Let us take any ``a'' such that p(a) is false, then the implication is true.
 
 
 
@@ -114,7 +114,7 @@ location to visit (\CodeInline{i} excluded), the memory location contains a
 value different from the element we are looking for.
 
 The verification condition associated to the preservation of this invariant is
-a bit complex and it is not really interesting to precisely look at it,
+a bit complex, and it is not interesting to precisely look at it,
 on the contrary, the proof that the invariant is established before
 executing the loop is interesting:
 
@@ -217,7 +217,7 @@ contain the new value. All other values must remain unchanged. While we
 previously relied on the \CodeInline{assigns} clauses for this kind of properties,
 here, we do not have this possibility because while the ACSL language provides
 some facilities that we could use to write a very precise \CodeInline{assigns}
-clause, WP would not perfectly exploit it. Thus we have to use an invariant and
+clause, WP would not perfectly exploit it. Thus, we have to use an invariant and
 keep an approximation of the assigned memory location.
 
 If we try to prove this invariant with WP, it fails. In such a case, the simpler
@@ -259,7 +259,7 @@ For all these exercises, use the following command line to start verification:
 frama-c-gui -wp -wp-rte -warn-unsigned-overflow -warn-unsigned-downcast your-file.c
 \end{CodeBlock}
 
-\levelFourTitle{Non-mutating: Forall, Exists, ...}
+\levelFourTitle{Non-mutating: For all, Exists, ...}
 
 
 Currently, function pointers are not supported by WP. Let us consider that
@@ -326,7 +326,7 @@ value, this index must be correctly bounded.
 
 \textbf{Harder:} Modify this function in order to receive \CodeInline{len}
 as a \CodeInline{size\_t}. You will have to slightly modify the algorithm
-and the proof. As an hint, we advise making \CodeInline{up} an excluded
+and the proof. As a hint, we advise making \CodeInline{up} an excluded
 bound for the search.
 
 
@@ -386,6 +386,6 @@ from the \CodeInline{i}$^{th}$ we are visiting to the end.
 
 
 Finally, it is also possible to write a function that copies the elements from
-the end to the beginning, in this case, again, arrays can overlap but the
+the end to the beginning, in this case, again, arrays can overlap, but the
 condition is not exactly the same. Write, specify and prove the function
 \CodeInline{copy\_backward} that copies elements in the reverse order.

--- a/english/statements/loops.tex
+++ b/english/statements/loops.tex
@@ -482,7 +482,7 @@ as if we had written:
 
 
 This is an interesting scheme. It basically corresponds to any algorithm
-that searches, using a loop, a particular condition respected by an element
+that searches, using a loop, a particular condition verified by an element
 in a given data-structure and stops when it founds it to perform some
 operations that are thus not really part of the loop. From a verification
 point of view, it allows us to simplify the contract of the loop: we know

--- a/english/statements/loops.tex
+++ b/english/statements/loops.tex
@@ -54,7 +54,6 @@ end of the last iteration that sets the value of \CodeInline{i} to $10$.
 
 To verify an invariant $I$, WP then produces the following
 ``reasoning'':
-
 \begin{itemize}
 \item
   verify that $I$ is true at the beginning of the loop (establishment)
@@ -72,20 +71,18 @@ $$\dfrac{\{I \wedge B \}\ c\ \{I\}}{\{I\}\ while(B)\{c\}\ \{I \wedge \neg B\}}$$
 And the weakest precondition calculus is the following:
 $$wp(while (B) \{ c \}, Post) := I \wedge ((B \wedge I) \Rightarrow wp(c, I)) \wedge ((\neg B \wedge I) \Rightarrow Post)$$
 Let us detail this formula:
-
 \begin{itemize}
 \item
   \begin{enumerate}
   \def\labelenumi{(\arabic{enumi})}
   \item
-    the first $I$ corresponds to the establishment of the invariant,
-    in layman's terms, this is the ``precondition'' of the loop,
+    The first $I$ corresponds to the establishment of the invariant,
+    in layman's terms, this is the ``precondition'' of the loop.
   \end{enumerate}
 \item
-  the second part of the conjunction
+  The second part of the conjunction
   ($(B \wedge I) \Rightarrow wp(c, I)$) corresponds to the
   verification of the operation performed by the body of the loop:
-
   \begin{itemize}
   \item
     the precondition that we know of the loop body (let us note $KWP$,
@@ -111,7 +108,7 @@ Let us detail this formula:
     previously explained.
   \end{itemize}
 \item
-  finally, the last part ($(\neg B \wedge I) \Rightarrow Post$)
+  Finally, the last part ($(\neg B \wedge I) \Rightarrow Post$)
   expresses the fact that when the loop ends($\neg B$), and the
   invariant $I$ has been maintained, it must imply that the wanted
   postcondition of the loop is verified.
@@ -214,14 +211,14 @@ It seems not.
 
 
 
-\levelThreeTitle{The assigns clause \ldots{} for loops}
+\levelThreeTitle{The \texttt{assigns} clause \ldots{} for loops}
 
 
 In fact, considering loops, WP \textbf{only} reasons about what is
 provided by the user to perform its reasoning. And here, the invariant
 does not specify anything about the way the value of \CodeInline{h} is
 modified (or not). We could specify the invariant of all program
-variables, but it would be a lot of work. ACSL simply allows to add
+variables, but it would be a lot of work. ACSL simply allows adding
 \CodeInline{assigns} annotations for loops. Any other variable is considered
 to keep its old value. For example:
 
@@ -286,7 +283,7 @@ The assertion ``False'' is proved! For a very simple reason: since the
 condition of the loop is ``True'' and no instruction of the loop body
 allows to leave the loop, it does not terminate. As we are proving the
 code with partial correctness, and as the execution does not terminate,
-we can prove anything about the code that follows the non terminating
+we can prove anything about the code that follows the non-terminating
 part of the code. However, if the termination is not trivially provable,
 the assertion will probably not be proved.
 
@@ -385,7 +382,7 @@ that this function returns the old value of \CodeInline{a} plus 10.
 
 
 
-The weakest precondition calculus does not allow to deduce information
+The weakest precondition calculus does not allow deducing information
 that is not part of the loop invariant. In a code like:
 
 
@@ -536,8 +533,8 @@ iterations and use it as a variant. You might need to add an invariant.
 
 
 Write a suitable loop assigns clause for this loop such that the assertion
-on line 8 is proved as well as the assigns clause. Let us ignore runtime
-errors in this proof.
+on line 8 is proved as well as the \CodeInline{assigns} clause. Let us ignore
+runtime errors in this proof.
 
 
 

--- a/french/acsl-logic-definitions.tex
+++ b/french/acsl-logic-definitions.tex
@@ -1,7 +1,4 @@
 Dans cette partie nous allons voir trois notions importantes d'ACSL :
-
-
-
 \begin{itemize}
 \item les définitions inductives,
 \item les définitions axiomatiques,

--- a/french/acsl-logic-definitions/axiomatic.tex
+++ b/french/acsl-logic-definitions/axiomatic.tex
@@ -85,7 +85,7 @@ dérouler la récursion quand c'est possible.
 
 
 
-L'idée est alors de ne pas définir directement la fonction ou le prédicat mais
+L'idée est alors de ne pas définir directement la fonction ou le prédicat, mais
 plutôt de la déclarer puis de définir des axiomes spécifiant son comportement.
 Si nous reprenons par exemple la factorielle, nous pouvons la définir
 axiomatiquement de cette manière :
@@ -133,7 +133,8 @@ d'une définition axiomatique qui prendra cette forme :
 \CodeBlockInput[5][16]{c}{reset-0.c}
 
 
-Notons le \CodeInline{reads[b .. e-1]} qui spécifie la position mémoire dont le
+Notons la présence de la clause \CodeInline{reads[b .. e-1]} qui spécifie la
+position mémoire dont le
 prédicat dépend. Tandis que nous n'avons pas besoin de spécifier les positions
 mémoires « lues » par une définition inductive, nous devons spécifier ces propriétés
 pour les propriétés définies axiomatiquement.
@@ -143,7 +144,7 @@ pour les propriétés définies axiomatiquement.
 
 
 En ajoutant des axiomes à notre base de connaissances, nous pouvons produire des
-preuves plus complexes car certaines parties de cette preuve, mentionnées par
+preuves plus complexes, car certaines parties de cette preuve, mentionnées par
 les axiomes, ne nécessiteront plus de preuves qui allongeraient le processus
 complet. Seulement, en faisant cela \textbf{nous devons être extrêmement prudents}.
 En effet, la moindre hypothèse fausse introduite dans la base pourraient rendre
@@ -152,7 +153,7 @@ basé sur des connaissances fausses, il ne nous apprendrait donc plus rien de co
 
 
 
-L'exemple le plus simple à produire est le suivant:
+L'exemple le plus simple à produire est le suivant :
 
 
 
@@ -190,7 +191,7 @@ consistance de l'axiomatique. En effet, comme mentionné précédemment, si nous
 n'exprimons pas les valeurs lues dans le cas de l'usage d'un pointeur, la
 modification d'une valeur du tableau n'invalide pas une propriété que l'on
 connaîtrait à propos du contenu du tableau par exemple. Dans un tel cas, la
-preuve passe mais l'axiome n'exprimant pas le contenu, nous ne prouvons rien.
+preuve passe, mais l'axiome n'exprimant pas le contenu, nous ne prouvons rien.
 
 
 
@@ -199,11 +200,7 @@ la définition de notre axiomatique en retirant la mention des valeurs dont
 dépendent le prédicat : \CodeInline{reads a[b .. e-1]}. La preuve passera toujours,
 mais n'exprimera plus rien à propos du contenu des tableaux considérés.
 Par exemple, la fonction suivante :
-
-
 \CodeBlockInput[16][25]{c}{all-zeroes-bad.c}
-
-
 est prouvée correcte alors qu'une valeur a changé dans le tableau et donc elle
 n'est plus 0.
 
@@ -227,9 +224,6 @@ axiomatiquement la notion de comptage dans un tableau :
 
 
 Nous avons trois cas à gérer :
-
-
-
 \begin{itemize}
 \item la plage de valeur concernée est vide : le nombre d'occurrences est 0 ;
 \item la plage de valeur n'est pas vide et le dernier élément est celui recherché :
@@ -276,7 +270,7 @@ erreurs. Ici, nous devrons quand même réaliser les preuves des propriétés
 mentionnées.
 
 
-\levelThreeTitle{Exemple: la fonction \CodeInline{strlen}}
+\levelThreeTitle{Exemple : la fonction \CodeInline{strlen}}
 
 
 Dans cette section, prouvons la fonction C \CodeInline{strlen}:
@@ -303,12 +297,12 @@ fonction logique \CodeInline{strlen} appliquée à cette chaîne. Bien sûr,
 cette fonction n'affecte rien. Définir ce qu'est une chaîne valide n'est
 pas si simple. En effet, précédemment dans ce tutoriel, nous avons uniquement
 travaillé avec des tableaux, en recevant en entrée à la fois un pointeur
-vers le tableau et la taille du dit tableau. Cependant ici, et tel que
+vers le tableau et la taille du tableau. Cependant, tel que
 c'est généralement fait en C, nous supposons que la chaîne termine avec
 un caractère \CodeInline{'\textbackslash{}0'}. Cela signifie que nous
 avons en fait besoin de la fonction logique \CodeInline{strlen} pour
 définir ce qu'est une chaîne valide. Utilisons d'abord cette définition
-(notons que nous utilisons \CodeInline{\textbackslash{}valid\_read}
+(notons que nous utilisons \CodeInline{\textbackslash{}valid\_read},
 car nous ne modifions pas la chaîne) pour fournir un contrat pour
 \CodeInline{strlen} :
 
@@ -319,7 +313,7 @@ car nous ne modifions pas la chaîne) pour fournir un contrat pour
 
 Définir la fonction logique \CodeInline{strlen} n'est pas si simple. En effet,
 nous devons calculer la fonction d'une chaîne en trouvant le caractère
-\CodeInline{'\textbackslash{}0'}, et nous espérons le trouver mais en fait,
+\CodeInline{'\textbackslash{}0'}, et nous espérons le trouver, mais en fait,
 nous pouvons facilement imaginer une chaîne qui n'en contiendrait pas. Dans
 ce cas, nous voudrions avoir une valeur d'erreur, mais il est impossible de
 garantir que le calcul termine : une fonction logique ne peut donc pas être
@@ -329,10 +323,10 @@ utilisée pour exprimer cette propriété.
 
 Définissons donc cette fonction axiomatiquement. D'abord définissons ce qui
 est lu par la fonction, à savoir : toute position mémoire depuis le pointeur
-jusqu'à un plage infinie d'adresses. Ensuite, considérons deux cas : la chaîne
+jusqu'à une plage infinie d'adresses. Ensuite, considérons deux cas : la chaîne
 est finie, ou elle ne l'est pas, ce qui nous amène à deux axiomes :
 \CodeInline{strlen} retourne une valeur positive qui correspond à l'indice
-du premier caractère \CodeInline{'\textbackslash{}0'}, et retourne une valeur
+du premier caractère \CodeInline{'\textbackslash{}0'} et retourne une valeur
 négative s'il n'y a pas de tel caractère.
 
 
@@ -344,7 +338,7 @@ négative s'il n'y a pas de tel caractère.
 Maintenant, nous pouvons être plus précis dans notre définition de
 \CodeInline{\textbackslash{}valid\_read\_string}, une chaîne valide est une
 chaîne telle qu'est valide depuis le premier indice jusqu'à \CodeInline{strlen}
-de la chaîne, et telle que cette valeur est plus grande que 0 (puisqu'une
+de la chaîne et telle que cette valeur est plus grande que 0 (puisqu'une
 chaîne infinie n'est pas valide) :
 
 
@@ -359,8 +353,8 @@ toute valeur entre 0 et \CodeInline{i}, elles sont différentes de
 et le variant correspond à la distance entre \CodeInline{i} et
 \CodeInline{strlen(s)}. Cependant, si nous essayons de prouver cette fonction,
 la preuve échoue. Pour avoir plus d'information, nous pouvons relancer la
-preuve avec la vérification d'absence de RTE, avec la vérification de non
-débordement des entiers non signés :
+preuve avec la vérification d'absence de RTE, avec la vérification de
+non-débordement des entiers non signés :
 
 
 
@@ -444,7 +438,7 @@ et la prouver :
 \levelFourTitle{Permutation}
 
 
-Reprendre l'exemple à propos du tri pr sélection
+Reprendre l'exemple à propos du tri par sélection
 (section~\ref{l3:acsl-logic-definitions-inductive-sort}). Ré-exprimer le
 prédicat de permutation comme une définition axiomatique. Prendre garde à la
 clause \CodeInline{reads} (en particulier, noter que le prédicat relie deux

--- a/french/acsl-logic-definitions/ghost-code.tex
+++ b/french/acsl-logic-definitions/ghost-code.tex
@@ -1,8 +1,8 @@
-Les techniques que nous avons vu précédemment dans ce chapitre ont pour but de
+Les techniques que nous avons vues précédemment dans ce chapitre ont pour but de
 rendre la spécification plus abstraite. Le rôle du code fantôme est inverse. Ici,
 nous enrichirons nos spécifications à l'aide d'information exprimées
 en langage C. L'idée est d'ajouter des variables et du code source qui
-n'intervient pas dans le programme réel mais permettant de créer des états
+n'intervient pas dans le programme réel, mais permettant de créer des états
 logiques qui ne seront visibles que depuis la preuve. Par cet intermédiaire,
 nous pouvons rendre explicites des propriétés logiques qui étaient auparavant
 implicites.
@@ -25,7 +25,7 @@ du code C ainsi que la mention \CodeInline{ghost}.
 
 
 Dans un code fantôme, nous écrivons du C normal. Nous expliquerons certaines
-petites subtilités plus tard. Pour l'instant, intéressons nous aux éléments
+petites subtilités plus tard. Pour l'instant, intéressons-nous aux éléments
 basiques que nous pouvons écrire avec du code fantôme.
 
 
@@ -118,7 +118,7 @@ void another_function(struct list* l){
 
 
 Notons que si une fonction prend des paramètres fantômes, tous les appels doivent
-fournir les arguments fantômes correspondant.
+fournir les arguments fantômes correspondants.
 
 
 Une fonction toute entière peut être fantôme. Par exemple, nous pourrions avoir
@@ -175,8 +175,6 @@ void foo(unsigned n){
 
 
 Frama-C vérifie plusieurs propriétés à propos du code fantôme que nous écrivons :
-
-
 \begin{itemize}
 \item le code fantôme ne peut pas modifier le graphe de flot de contrôle
       du programme ;
@@ -231,7 +229,7 @@ itération. En conséquence, ce programme sera rejeté par Frama-C :
 \end{CodeBlock}
 
 
-Il est important de noter que lorsqu'un code fantôme altère le flot de contrôle
+Il est important de noter que lorsqu'un code fantôme altère le flot de contrôle,
 c'est le point de départ du code fantôme qui est pointé par l'erreur, par exemple
 si nous introduisons une conditionnelle autour de notre \CodeInline{break} :
 
@@ -290,14 +288,8 @@ Refuser que le code normal voie le code fantôme a une raison toute simple. Si l
 code normal tentait d'accéder à des variables fantômes, il ne pourrait même pas
 être compilé : le compilateur ne voit pas les variables déclarées dans les
 annotations. Par exemple :
-
-
 \CodeBlockInput[6]{c}{non-ghost-access-ghost.c}
-
-
 ne peut pas être compilé :
-
-
 \begin{CodeBlock}{text}
 # gcc -c file.c
 file.c: In function ‘sum_42’:
@@ -305,11 +297,7 @@ file.c:5:10: error: ‘r’ undeclared (first use in this function)
     5 |     x += r;
       |          ^
 \end{CodeBlock}
-
-
 et n'est donc pas accepté par Frama-C non plus :
-
-
 \begin{CodeBlock}{text}
 [kernel] file.c:5: User Error:
   Variable r is a ghost symbol. It cannot be used in non-ghost context. Did you forget a /*@ ghost ... /?
@@ -498,10 +486,11 @@ de modifier \CodeInline{x} dans du code fantôme. En conséquence, une telle
 conversion n'est jamais autorisée.
 
 
-Finalement, le code fantôme ne peut actuellement pas appeler de fonction non
-fantôme, pour des raisons semblables à celle évoquée pour l'interdiction de toutes
-les conversions. Certains cas particuliers pourraient être traités de manière à
-accepter plus de code, mais ce n'est actuellement pas supporté par Frama-C.
+Finalement, le code fantôme ne peut actuellement pas appeler de fonction qui
+n'est pas fantôme, pour des raisons semblables à celle évoquée pour
+l'interdiction de toutes les conversions. Certains cas particuliers pourraient
+être traités de manière à accepter plus de code, mais ce n'est actuellement pas
+supporté par Frama-C.
 
 
 \levelThreeTitle{Validité du code fantôme, ce qu'il reste à vérifier}
@@ -512,8 +501,6 @@ Mis à part les restrictions que nous avons mentionnées dans la section précé
 le code fantôme est juste du code C normal. Cela veut dire que si nous voulons
 faire la vérification de notre programme d'origine, nous devons faire attention,
 nous-mêmes, à au moins deux aspects supplémentaires :
-
-
 \begin{itemize}
 \item l'absence d'erreurs à l'exécution,
 \item la terminaison du code fantôme.
@@ -530,7 +517,7 @@ a deux sortes de correction : la correction partielle et la correction totale,
 la seconde permettant de prouver qu'un programme termine. Dans le cas du code
 normal, montrer la terminaison n'est pas toujours souhaitable pour l'ensemble
 du programme. En revanche, si nous utilisons du code fantôme pour aider la
-vérification, montrer que la correction est totale est absolument nécessaire
+vérification, montrer que la correction est totale est absolument nécessaire,
 car une boucle infinie dans le code fantôme peut nous permettre de prouver
 n'importe quoi à propos du programme.
 
@@ -577,7 +564,7 @@ renverra donc 6.
 
 
 Pour spécifier la fonction précédente, nous aurons besoin d'exprimer
-axiomatiquement la somme. Ce n'est pas très complexe, et le lecteur pourra
+axiomatiquement la somme. Ce n'est pas très complexe et le lecteur pourra
 s'exercer en exprimant les axiomes nécessaires au bon fonctionnement de cette
 axiomatique :
 
@@ -604,8 +591,8 @@ une paire de bornes telle que la somme des éléments entre ces bornes est
 exactement la valeur retournée par la fonction. Par rapport à cette spécification,
 si nous devons ajouter les invariants de boucles, nous nous apercevons rapidement
 qu'il nous manquera des informations. Nous avons besoin d'exprimer ce que sont
-les valeurs \CodeInline{max} et \CodeInline{cur} et quelles relations existent entre elles,
-mais rien ne nous le permet !
+les valeurs \CodeInline{max} et \CodeInline{cur}, et quelles relations existent
+entre elles, mais rien ne nous le permet !
 
 
 

--- a/french/acsl-logic-definitions/inductive.tex
+++ b/french/acsl-logic-definitions/inductive.tex
@@ -155,7 +155,7 @@ Pour notre définition de \CodeInline{even\_natural}, cela donnerait :
 \CodeBlockInput[17][22]{c}{even-bad.c}
 
 
-Pendant la génération de l'obligation de preuve, WP demande à Why3 de
+Pendant la génération de la condition de vérification, WP demande à Why3 de
 créer une définition inductive pour celle que nous avons écrit en ACSL.
 Comme Why3 est plus strict que Frama-C et WP pour ce type de définition,
 si le prédicat inductif est trop étrange (s'il n'est pas bien fondé), il

--- a/french/acsl-logic-definitions/inductive.tex
+++ b/french/acsl-logic-definitions/inductive.tex
@@ -15,7 +15,6 @@ naturel supérieur à 0 est pair, on peut regarder si ce naturel moins 2 est pai
 
 
 Pour le moment, introduisons la syntaxe des prédicats inductifs :
-
 \begin{CodeBlock}{c}
 /*@
   inductive property{ Label0, ..., LabelN }(type0 a0, ..., typeN aN) {
@@ -25,15 +24,13 @@ Pour le moment, introduisons la syntaxe des prédicats inductifs :
   }
 */
 \end{CodeBlock}
-
-
 où tous les \CodeInline{c\_i} sont des noms et tous les \CodeInline{p\_i} sont
 des formules logiques où \CodeInline{property} apparaît en conclusion. Pour résumer,
 \CodeInline{property} est vraie pour certains paramètres et labels mémoire, s'ils
 valident l'un des cas du prédicat inductif.
 
 
-Jetons un oeil à la petite propriété dont nous parlions plus tôt : comment définir
+Jetons un \oe{}il à la petite propriété dont nous parlions plus tôt : comment définir
 qu'un entier naturel est pair par induction ? Nous pouvons traduire la phrase :
 « 0 est un naturel pair, et si $n$ est un naturel pair, alors $n+2$ est aussi un
 naturel pair ».
@@ -74,7 +71,7 @@ Ici nous distinguons à nouveau deux cas :
 \end{itemize}
 
 
-Pour un entier naturel donné, s'il est plus grand que 0, nous déminuerons
+Pour un entier naturel donné, s'il est plus grand que 0, nous diminuerons
 récursivement sa valeur jusqu'à atteindre 0 ou -1. Dans le cas 0, l'entier
 naturel est pair. Dans le cas -1, nous n'aurons aucun cas du prédicat inductif
 qui corresponde
@@ -107,14 +104,11 @@ conseils pour ne pas construire une mauvaise définition.
 D'abord, nous pouvons nous assurer que les prédicats inductifs sont bien fondés.
 Cela peut être fait en restreignant syntaxiquement ce que nous acceptons dans
 une définition inductive en nous assurant que chaque cas est de la forme :
-
 \begin{CodeBlock}{c}
 /*@
   \forall y1,...,ym ; h1 ==> ··· ==> hl ==> P(t1,...,tn) ;
 */
 \end{CodeBlock}
-
-
 où le prédicat \CodeInline{P} ne peut apparaître que positivement (donc sans la
 négation \CodeInline{!} - $\neg$) dans les différentes hypothèses \CodeInline{hx}.
 Intuitivement, cela assure que nous ne pouvons pas construire des occurrences à la
@@ -125,11 +119,7 @@ fois positives et négatives de \CodeInline{P} pour un ensemble de paramètres d
 
 Cette propriété est par exemple vérifiée pour notre définition précédente du
 prédicat \CodeInline{even\_natural}. Tandis qu'une définition comme :
-
-
 \CodeBlockInput[5][15]{c}{even-bad.c}
-
-
 ne respecte pas cette contrainte, car la propriété \CodeInline{even\_natural}
 apparaît négativement à la ligne~8.
 
@@ -176,7 +166,7 @@ frama-c-gui -wp -wp-prop=BAD file.c
 
 Cependant, cela ne signifie pas que nous ne pouvons pas écrire une définition
 inductive inconsistante. Par exemple, la définition inductive suivante est bien
-fondée mais nous permet de prouver faux :
+fondée, mais nous permet de prouver faux :
 
 
 \begin{CodeBlock}{c}
@@ -284,7 +274,7 @@ Nous allons prouver un simple tri par sélection :
 
 Le lecteur pourra s'exercer en spécifiant et en prouvant les fonctions de
 recherche de minimum et d'échange de valeur. Nous cachons la correction
-(Réponses:~\ref{l2:acsl-logic-definitions-answers}) et nous nous concentrerons
+(Réponses :~\ref{l2:acsl-logic-definitions-answers}) et nous nous concentrerons
 plutôt sur la spécification et la preuve de la fonction de tri qui sont une
 illustration intéressante de l'usage des définitions inductives.
 
@@ -323,9 +313,9 @@ extrêmement bien par l'utilisation d'une définition inductive. En effet, pour
 déterminer qu'un tableau est la permutation d'un autre, les cas sont très limités.
 Premièrement, le tableau est une permutation de lui-même, puis l'échange de
 deux valeurs sans changer les autres est également une permutation, et
-finalement si nous créons la permutation $p_2$ d'une permutation $p_1$, puis que
-nous créons la permutation $p_3$ de $p_2$, alors par transitivité $p_3$ est une
-permutation de $p_1$.
+finalement si nous créons la permutation $p_2$ d'une permutation $p_1$, puis
+la permutation $p_3$ de $p_2$, alors par transitivité $p_3$ est une permutation
+de $p_1$.
 
 
 
@@ -391,7 +381,6 @@ commun de deux autres. Le but de cet exercice est de prouver que la fonction
 nous pouvons voir qu'après la première itération, \CodeInline{a} est supérieur ou
 égal à \CodeInline{b}, et que cette propriété est maintenue par la boucle. Donc,
 considérons deux cas pour le prédicat inductif :
-
 \begin{itemize}
 \item \CodeInline{b} est 0,
 \item si une valeur \CodeInline{d} est le PGCD de \CodeInline{b} et \CodeInline{a \% b},
@@ -415,8 +404,8 @@ Dans cet exercice, nous ne considérerons pas les RTE.
 
 
 Écrire un prédicat inductif qui exprime qu'un entier \CodeInline{r} est égal
-à $x^n$. Considérer deux cas : soit $n$ est 0, soit il est plus grand et à ce moment
-là, la valeur de \CodeInline{r} est reliée à la valeur $x^{n-1}$.
+à $x^n$. Considérer deux cas : soit $n$ est 0, soit il est plus grand et à ce
+moment-là, la valeur de \CodeInline{r} est reliée à la valeur $x^{n-1}$.
 
 
 \CodeBlockInput[5][10]{c}{ex-3-fpower.c}
@@ -444,7 +433,7 @@ Dans cette version, nous exploitons deux propriétés de l'opérateur puissance 
 
 
 Qui permet de diviser $n$ par 2 à chaque tour de boucle au lieu de le décrémenter
-de un (ce qui permet à l'algorithme d'être en $O(\log n)$ et pas $O(n)$). Exprimer
+de 1 (ce qui permet à l'algorithme d'être en $O(\log n)$ et pas $O(n)$). Exprimer
 les deux propriétés précédentes sous forme de lemmes :
 
 
@@ -486,7 +475,6 @@ cellule de la plage de valeur. Utiliser ce prédicat pour prouver la fonction
 
 Exprimer une nouvelle version de la notion de permutation avec un prédicat inductif
 qui considère les cas suivants :
-
 \begin{itemize}
 \item la permutation est réflexive ;
 \item si la partie gauche d'une plage de valeur (jusqu'à un certain indice) est

--- a/french/acsl-properties.tex
+++ b/french/acsl-properties.tex
@@ -1,18 +1,18 @@
 
-Depuis le début de ce tutoriel, nous avons vu divers prédicats et fonctions 
+Depuis le début de ce tutoriel, nous avons vu divers prédicats et fonctions
 logiques qui sont fournis par défaut en ACSL : \CodeInline{\textbackslash{}valid}, \CodeInline{\textbackslash{}valid\_read},
-\CodeInline{\textbackslash{}separated}, \CodeInline{\textbackslash{}old} et \CodeInline{\textbackslash{}at}. Il en existe bien sûr d'autres mais 
-nous ne les présenterons pas un à un ; le lecteur pourra se référer à 
-\externalLink{la documentation (ACSL implementation)}{http://frama-c.com/download.html} 
+\CodeInline{\textbackslash{}separated}, \CodeInline{\textbackslash{}old} et \CodeInline{\textbackslash{}at}. Il en existe bien sûr d'autres, mais
+nous ne les présenterons pas un à un ; le lecteur pourra se référer à
+\externalLink{la documentation (ACSL implementation)}{https://frama-c.com/html/get-frama-c.html}
 pour cela (à noter : tout n'est pas nécessairement supporté par WP).
 
 
 
-ACSL permet de faire plus que « simplement » spécifier notre code. Nous 
+ACSL permet de faire plus que « simplement » spécifier notre code. Nous
 pouvons définir nos propres prédicats, fonctions, relations, etc. Le but est de
-pouvoir abstraire nos spécifications. Cela nous permet de les factoriser (par 
-exemple en définissant ce qu'est un tableau valide), ce qui a deux effets 
-positifs : d'abord nos spécifications deviennent plus lisibles donc 
+pouvoir abstraire nos spécifications. Cela nous permet de les factoriser (par
+exemple en définissant ce qu'est un tableau valide), ce qui a deux effets
+positifs : d'abord nos spécifications deviennent plus lisibles donc
 plus faciles à comprendre, mais cela permet également de réutiliser des preuves
 déjà faites et donc de faciliter la preuve de nouveaux programmes.
 
@@ -43,24 +43,24 @@ déjà faites et donc de faciliter la preuve de nouveaux programmes.
 
 
 
-Dans cette partie, nous avons vu les constructions de ACSL qui nous permettent 
-de factoriser un peu nos spécifications et d'exprimer des propriétés générales 
+Dans cette partie, nous avons vu les constructions de ACSL qui nous permettent
+de factoriser un peu nos spécifications et d'exprimer des propriétés générales
 pouvant être utilisées par les prouveurs pour faciliter leur travail.
 
 
 
-Toutes les techniques expliquées dans cette partie sont sûres, au sens où 
-elles ne permettent \textit{a priori} pas de fausser la preuve avec des définitions 
-fausses ou contradictoires. En tous cas, si la spécification n'utilise que ce
-type de constructions et que chaque lemme, chaque précondition (aux points 
-d'appel), chaque postcondition, chaque assertion, chaque variant et chaque 
+Toutes les techniques expliquées dans cette partie sont sûres, au sens où
+elles ne permettent \textit{a priori} pas de fausser la preuve avec des définitions
+fausses ou contradictoires. En tout cas, si la spécification n'utilise que ce
+type de constructions et que chaque lemme, chaque précondition (aux points
+d'appel), chaque postcondition, chaque assertion, chaque variant et chaque
 invariant est correctement prouvé, le code est juste.
 
 
 
-Parfois ces constructions ne sont pas suffisantes pour exprimer toutes nos 
+Parfois ces constructions ne sont pas suffisantes pour exprimer toutes nos
 propriétés ou pour prouver nos programmes. Les prochaines constructions que nous
-verrons ajouteront de nouvelles possibilités à ce sujet, mais il 
-faudra se montrer prudent dans leur usage car des erreurs pourraient nous 
-permettre de créer des hypothèses fausses ou d'altérer le programme que nous 
+verrons ajouteront de nouvelles possibilités à ce sujet, mais il
+faudra se montrer prudent dans leur usage, car des erreurs pourraient nous
+permettre de créer des hypothèses fausses ou d'altérer le programme que nous
 vérifions.

--- a/french/acsl-properties/functions.tex
+++ b/french/acsl-properties/functions.tex
@@ -47,9 +47,9 @@ Elle peut nous servir à prouver le code de la fonction suivante :
 \image{linear-1}
 
 
-Le code est bien prouvé mais les contrôles d'\textit{overflow}, eux, ne le sont pas.
+Le code est bien prouvé, mais les contrôles d'\textit{overflow}, eux, ne le sont pas.
 Nous pouvons ajouter la contrainte en précondition que le calcul doit entrer dans
-les bornes d'un entier:
+les bornes d'un entier :
 
 
 \CodeBlockInput[8][15]{c}{linear-1.c}
@@ -64,13 +64,13 @@ exemple ici, le fait \CodeInline{3 * x + 4} ne soit pas inférieur à
 le problème, ce choix doit être guidé par les besoins du projet.
 
 
-Soit nous pouvons augmenter les restrictions sur l'entrée :
+Nous pouvons augmenter les restrictions sur l'entrée :
 
 
 \CodeBlockInput[17][25]{c}{linear-1.c}
 
 
-Soit nous pouvons modifier le code de manière à corriger le risque
+Ou nous pouvons modifier le code de manière à corriger le risque
 de débordement :
 
 
@@ -130,14 +130,14 @@ précondition :
 
 
 
-Si nous demandons la preuve avec cette entrée, Alt-ergo échouera pratiquement à
+Si nous demandons la preuve avec cette entrée, Alt-Ergo échouera pratiquement à
 coup sûr. En revanche, le prouveur Z3 produit la preuve en moins d'une seconde.
 Parce que dans ce cas précis, les heuristiques de Z3 considèrent que c'est une
 bonne idée de passer un peu plus de temps sur l'évaluation de la fonction.
 
 
 
-Les fonctions logiques peuvent donc être définies récursivement mais sans astuces
+Les fonctions logiques peuvent donc être définies récursivement, mais sans astuces
 supplémentaires, nous venons vite nous heurter au fait que les prouveurs vont au
 choix devoir faire de l'évaluation, ou encore « raisonner » par induction, deux
 tâches pour lesquelles ils ne sont pas du tout faits, ce qui limite nos
@@ -210,7 +210,7 @@ label \CodeInline{L2}.
 \CodeBlockInput[5]{c}{ex-4-vec-inc.c}
 
 
-Ré-exprimer la prédicat \CodeInline{unchanged} en utilisant la fonction logique.
+Ré-exprimer le prédicat \CodeInline{unchanged} en utilisant la fonction logique.
 
 
 
@@ -229,7 +229,7 @@ retourne la même valeur que celle fournie par la fonction logique.
 
 Essayer de vérifier l'absence d'erreurs à l'exécution. Le débordement entier
 n'est pas si simple à régler. Cependant, écrire une précondition qui devrait
-être suffisante pour cela (rappel: la somme des N premiers entiers peut être
+être suffisante pour cela (rappel : la somme des N premiers entiers peut être
 exprimée avec une formule très simple ...). Cela ne sera sûrement pas suffisant
 pour arriver au bout de la preuve, mais nous réglerons cela dans la prochaine
 section.

--- a/french/acsl-properties/lemmas.tex
+++ b/french/acsl-properties/lemmas.tex
@@ -13,11 +13,11 @@ amène de $P$ à $Q$.
 
 
 
-Dans la section précédent, nous avons dit que les fonctions récursives logiques
-peuvent rendre les preuves plus difficile pour les solveurs SMT. Dans un tel cas,
+Dans la section précédente, nous avons dit que les fonctions récursives logiques
+peuvent rendre les preuves plus difficiles pour les solveurs SMT. Dans un tel cas,
 les lemmes peuvent nous aider. Nous pouvons écrire nous même les preuves qui
 nécessitent de raisonner par induction pour certaines propriétés que nous
-énonçons comme des lemmes, et ces lemmes peuvent ensuite être utilisés
+énonçons comme des lemmes. Ces lemmes peuvent ensuite être utilisés
 efficacement par les prouveurs pour effectuer les autres preuves à propos du
 programme.
 
@@ -72,7 +72,7 @@ propriétés intéressantes à leur sujet :
 
 
 
-Pour ces preuves, il est fort possible qu'Alt-ergo ne parvienne pas à les
+Pour ces preuves, il est fort possible qu'Alt-Ergo ne parvienne pas à les
 décharger. Dans ce cas, le prouveur Z3 devrait, lui, y arriver. Nous pouvons
 ensuite construire cet exemple de code :
 
@@ -83,16 +83,16 @@ ensuite construire cet exemple de code :
 
 
 Si nous ne renseignons pas les lemmes mentionnés plus tôt, il y a peu de chances
-qu'Alt-ergo réussisse à produire la preuve que \CodeInline{fmin} est inférieur à \CodeInline{fmax}.
-Avec ces lemmes présents en revanche, il y parvient sans problème car cette
+qu'Alt-Ergo réussisse à produire la preuve que \CodeInline{fmin} est inférieur à \CodeInline{fmax}.
+Avec ces lemmes présents en revanche, il y parvient sans problème, car cette
 propriété est une simple instance du lemme \CodeInline{ax\_b\_monotonic\_pos}, la preuve
-étant ainsi triviale car notre lemme nous énonce cette propriété comme étant vraie.
+étant ainsi triviale, car notre lemme nous énonce cette propriété comme étant vraie.
 Notons que sur cette version généralisée, Z3 sera probablement plus efficace pour
 prouver l'absence d'erreurs à l'exécution.
 
 
 
-\levelThreeTitle{Exemple: tableaux et labels}
+\levelThreeTitle{Exemple : tableaux et labels}
 
 
 Plus tard dans ce tutoriel, nous verrons certains types de définitions à propos
@@ -103,7 +103,7 @@ entre deux labels.
 
 
 Pour le moment, illustrons cela avec un exemple simple. Considérons les deux
-prédicats suivant :
+prédicats suivants :
 
 
 \CodeBlockInput[1][8]{c}{unchanged-sorted.c}
@@ -120,7 +120,7 @@ avec le lemme suivant :
 
 Nous énonçons ce lemme pour deux labels \CodeInline{L1} et \CodeInline{L2}, et
 exprimons que pour toute plage de valeurs dans un tableau, si elle est triée au label
-\CodeInline{L1}, et reste inchangée depuis \CodeInline{L1} vers \CodeInline{L2},
+\CodeInline{L1} et reste inchangée depuis \CodeInline{L1} vers \CodeInline{L2},
 alors elle reste triée au label \CodeInline{L2}.
 
 
@@ -159,10 +159,10 @@ puis appelle la fonction de recherche dichotomique.
 Pour cet exercice, reprendre la solution de
 l'exercice~\ref{l4:acsl-properties-predicates-ex-bsearch} à propos de la recherche
 dichotomique. La précondition de cette recherche peut sembler plus forte que celle
-reçue par la précondition de de \CodeInline{bsearch\_callee}. La première demande
+reçue par la précondition de \CodeInline{bsearch\_callee}. La première demande
 chaque paire d'éléments d'être ordonnée, la seconde simplement que chaque élément
 soit inférieur à celui qui le suit. Cependant, la seconde implique la première.
-Écrire un un lemme qui énonce que si \CodeInline{element\_level\_sorted} est vraie
+Écrire un lemme qui énonce que si \CodeInline{element\_level\_sorted} est vraie
 pour un tableau, \CodeInline{sorted} est vraie aussi. Ce lemme ne sera probablement
 pas prouvé par un solveur SMT, toutes les autres propriétés devraient être prouvées
 automatiquement.

--- a/french/acsl-properties/predicates.tex
+++ b/french/acsl-properties/predicates.tex
@@ -114,7 +114,7 @@ cas particulier des plages qui commencent à 0 :
 
 Une autre utilité importante des prédicats est de définir l'état logique de nos
 structures quand les programmes se complexifient. Nos structures doivent
-généralement respecter un invariant (encore) que chaque fonction de manipulation
+généralement avoir un invariant (encore) que chaque fonction de manipulation
 devra maintenir pour assurer que la structure sera toujours utilisable et
 qu'aucune fonction ne commettra de bavure.
 

--- a/french/acsl-properties/predicates.tex
+++ b/french/acsl-properties/predicates.tex
@@ -42,14 +42,12 @@ pas changé entre deux points particuliers du programme :
 \begin{Warning}
   Il faut bien garder en mémoire que le passage se fait, comme en C, par valeur.
   Nous ne pouvons pas écrire ce prédicat en passant directement \CodeInline{i} :
-
   \begin{CodeBlock}{c}
     /*@
       predicate unchanged{L0, L1}(int i) =
         \at(i, L0) == \at(i, L1);
     */
   \end{CodeBlock}
-
   car \CodeInline{i} est juste une copie de la variable reçue en paramètre.
 \end{Warning}
 
@@ -71,7 +69,7 @@ déroulé par WP. Ce sera au prouveur de déterminer s'il veut raisonner avec.
 
 Comme nous l'avons dit plus tôt, une des utilités des prédicats et fonctions (que
 nous verrons un peu plus tard) est de rendre plus lisible nos spécifications et
-de les factoriser. Un exemple est l''écriture d'un prédicat pour la validité en
+de les factoriser. Un exemple est l'écriture d'un prédicat pour la validité en
 lecture/écriture d'un tableau sur une plage particulière. Cela nous évite d'avoir
 à réécrire l'expression en question qui est moins compréhensible au premier
 coup d’œil.
@@ -128,11 +126,11 @@ limitée. Et cela donnerait quelque chose comme :
 \CodeBlockInput[5]{c}{stack.c}
 
 
-(Notons qu'ici, nous ne fournissons pas la définition des prédicats car ce n'est
+(Notons qu'ici, nous ne fournissons pas la définition des prédicats, car ce n'est
 pas l'objet de cet exemple. Le lecteur pourra considérer ceci comme un exercice.)
 
 Ici, la spécification n'exprime pas de propriétés fonctionnelles. Par exemple,
-rien ne nous spécifie que lorsque nous faisons un \textit{push} d'une valeur puis que nous
+rien ne nous spécifie que lorsque nous faisons un \textit{push} d'une valeur puis
 demandons \textit{top}, nous auront effectivement cette valeur. Mais elle nous donne
 déjà tout ce dont nous avons besoin pour produire un code où, à défaut d'avoir
 exactement les résultats que nous attendons (des comportements tels que « si
@@ -158,7 +156,7 @@ de façon à l'utiliser.
 
 Reprendre la solution de l'exercice~\ref{l4:contract-modularity-ex-alpha-num} à
 propos des caractères alpha-numériques. Écrire des prédicats pour exprimer qu'un
-caractères est une majuscule, une autre pour les minuscules, et un dernier pour les
+caractère est une majuscule, une autre pour les minuscules et un dernier pour les
 chiffres. Adapter les contrats des différentes fonctions en les utilisant.
 
 
@@ -193,7 +191,7 @@ qu'elle le vérifie.
 
 
 Reprendre la solution de l'exercice~\ref{l4:statements-loops-ex-bsearch} à propos
-de la recherche dichotomique utilisant des indices non-signés. Écrire un prédicat
+de la recherche dichotomique utilisant des indices non signés. Écrire un prédicat
 qui exprime qu'une plage de valeur est triée entre \CodeInline{begin} et
 \CodeInline{end} (exclu). Écrire une surcharge de ce prédicat pour rendre
 \CodeInline{begin} optionnel avec une valeur par défaut à $0$. Écrire un prédicat
@@ -214,7 +212,6 @@ Reprendre l'exemple~\ref{l4:statements-loops-ex-search-and-replace}, à propos d
 la fonction « chercher et remplacer ». Écrire des prédicats qui exprime qu'une plage
 de valeurs dans un tableau pour des indices compris entre \CodeInline{begin} et
 \CodeInline{end} (exclu), les valeurs :
-
 \begin{itemize}
   \item restent inchangées entre deux états mémoire,
   \item sont remplacées par une valeur si elles sont égales à une valeur donnée,

--- a/french/conclusion.tex
+++ b/french/conclusion.tex
@@ -199,10 +199,10 @@ l'analyse du code source et Frama-C permet de forger différentes analyses.
 \levelThreeTitle{Avec la preuve déductive}
 
 
-Tout au long du tutoriel, nous avons utilisé WP pour générer des obligations de
-preuve à partir de programmes et de leurs spécifications. Par la suite, nous avons
-utilisé des solveurs automatiques pour assurer que les propriétés en question sont
-bien vérifiées.
+Tout au long du tutoriel, nous avons utilisé WP pour générer des conditions de
+vérification à partir de programmes et de leurs spécifications. Par la suite,
+nous avons utilisé des solveurs automatiques pour assurer que les propriétés en
+question sont bien vérifiées.
 
 
 
@@ -216,12 +216,12 @@ certain nombre de structures de données.
 
 
 Il y a un certain nombre de preuves qui ne peuvent être déchargées par les
-prouveurs automatiques. Dans ce genre de cas, nous devons nous rabattre sur de la
-preuve interactive. WP comme Why3 peuvent extraire vers Coq, et il est très
-intéressant d'étudier ce langage, il peut par exemple servir à constituer des
-bibliothèques de lemmes génériques et prouvés. À noter que Why3 peut également
-extraire ses obligations vers Isabelle ou PVS qui sont d'autres assistants de
-preuve.
+prouveurs automatiques. Dans ce genre de cas, nous devons nous rabattre sur de
+la preuve interactive. Why3 peut par extraire des conditions de vérification
+vers Coq, et il est très intéressant d'étudier ce langage, il peut par exemple
+servir à constituer des bibliothèques de lemmes génériques et prouvés. À noter
+que Why3 peut également extraire ses conditions de vérification vers Isabelle ou
+PVS qui sont d'autres assistants de preuve.
 
 
 

--- a/french/conclusion.tex
+++ b/french/conclusion.tex
@@ -12,9 +12,9 @@ Tout au long de ce tutoriel, nous avons vu comment utiliser ces outils
 pour spécifier ce que nous attendons de nos programmes et vérifier que le code
 produit correspond effectivement à la spécification que nous en
 avons faite. Cette spécification passe par l'annotation de nos fonctions avec
-le contrat qu'elle doit respecter, c'est-à-dire les propriétés que doivent
-respecter les entrées de la fonction pour garantir son bon fonctionnement et
-les propriétés que celle-ci s'engage à assurer sur les sorties en retour,
+le contrat auquel elle doit se conformer, c'est-à-dire les propriétés que
+doivent vérifier les entrées de la fonction pour garantir son bon fonctionnement
+et les propriétés que celle-ci s'engage à assurer sur les sorties en retour,
 associées aux contrôles que nous impose l'outil à propos des problèmes
 spécifiques au langage C (plus particulièrement, montrer l'absence de
 \textit{runtime errors}).

--- a/french/conclusion.tex
+++ b/french/conclusion.tex
@@ -54,7 +54,7 @@ void ma_fonction(int* a, int b){
 
 
 Ce qui nous permet ainsi de bénéficier de la robustesse de notre fonction tout en
-ayant la possibilité de débugger un appel incorrect dans un code que nous ne
+ayant la possibilité de déboguer un appel incorrect dans un code que nous ne
 voulons ou pouvons pas prouver.
 
 
@@ -86,7 +86,7 @@ ont cela pour elles. Qu'y a-t-il de plus terrible que lire une spécification
 rallonge, de verbes conjugués à la forme conditionnelle, de termes imprécis,
 d'ambiguïtés, compilée dans des documents administratifs de centaines de pages,
 et dans laquelle nous devons chercher pour déterminer « bon alors cette fonction,
-elle doit faire quoi ? Et qu'est-ce qu'il faut valider à son sujet ? ».
+elle doit faire quoi ? Et que faut-il valider à son sujet ? ».
 
 
 
@@ -147,13 +147,10 @@ toujours fragile.}
 \levelThreeTitle{Avec Frama-C}
 
 
-Frama-C propose divers moyen d'analyser les programmes. Dans les outils les
+Frama-C propose divers moyens d'analyser les programmes. Dans les outils les
 plus courants qui sont intéressants à connaître d'un point de vue vérification
 statique et dynamique pour l'évaluation du bon fonctionnement d'un programme,
 on peut citer :
-
-
-
 \begin{itemize}
 \item l'analyse par interprétation abstraite avec
 \externalLink{EVA}{http://frama-c.com/value.html},
@@ -206,7 +203,7 @@ question sont bien vérifiées.
 
 
 
-Lorsque nous passons par d'autres solveurs que Alt-Ergo, le dialogue avec ceux-ci
+Lorsque nous passons par d'autres solveurs qu'Alt-Ergo, le dialogue avec ceux-ci
 est assuré par une traduction vers le langage de Why3 qui fait ensuite le pont
 avec les prouveurs automatiques. Mais ce n'est pas la seule manière d'utiliser
 Why3. Celui-ci peut tout à fait être utilisé seul pour écrire et prouver des

--- a/french/function-contract/behaviors.tex
+++ b/french/function-contract/behaviors.tex
@@ -51,15 +51,12 @@ le comportement, la fonction doit retourner une valeur positive.
 
 Pour comprendre ce que font précisément \CodeInline{complete} et \CodeInline{disjoint}, il est utile
 d'expérimenter deux possibilités :
-
-
-
 \begin{itemize}
 \item remplacer l'hypothèse de « pos » par \CodeInline{val > 0} auquel cas les
-comportements seront disjoints mais incomplets (il nous manquera le cas
+comportements seront disjoints, mais incomplets (il nous manquera le cas
 \CodeInline{val == 0}) ;
 \item remplacer l'hypothèse de « neg » par \CodeInline{val <= 0} auquel cas les
-comportements seront complets mais non disjoints (le cas \CodeInline{val == 0}) sera
+comportements seront complets, mais non disjoints (le cas \CodeInline{val == 0}) sera
 présent dans les deux comportements.
 \end{itemize}
 
@@ -68,7 +65,6 @@ présent dans les deux comportements.
 Même si \CodeInline{assigns} est une postcondition, à ma connaissance, il n'est pas
 possible de mettre des \CodeInline{assigns} pour chaque \textit{behavior}. Si nous avons
 besoin d'un tel cas, nous spécifions :
-
 \begin{itemize}
 \item \CodeInline{assigns} avant les \textit{behavior} (comme dans notre exemple) avec tout
 élément non-local susceptible d'être modifié,
@@ -81,7 +77,7 @@ pas modifiés en les indiquant égaux à leur ancienne (\CodeInline{\textbacksla
 Les comportements sont très utiles pour simplifier l'écriture de spécifications
 quand les fonctions ont des effets très différents en fonction de leurs
 entrées. Sans eux, les spécifications passent systématiquement par des
-implications traduisant la même idée mais dont l'écriture et la lecture sont
+implications traduisant la même idée, mais dont l'écriture et la lecture sont
 plus difficiles (nous sommes susceptibles d'introduire des erreurs).
 D'autre part, la traduction de la complétude et de la disjonction devraient
 être écrites manuellement, ce qui serait fastidieux et une nouvelle fois source
@@ -96,8 +92,6 @@ d'erreurs.
 
 
 Dans les sections précédentes, reprendre les exemples :
-
-
 \begin{itemize}
 \item à propos du calcul de la distance entre deux entiers ;
 \item « Remettre à zéro selon une condition » ;
@@ -143,8 +137,6 @@ arbitrairement l'un des quadrants qu'elle touche.
 
 Compléter les fonctions suivantes qui reçoivent la longueur des différents
 côtés et retournent respectivement :
-
-
 \begin{itemize}
 \item si le triangle est scalène, isocèle, ou équilatéral ;
 \item si le triangle est rectangle, acutangle ou obtusangle.
@@ -179,13 +171,13 @@ valeur. En considérant que le contrat était :
 
 \begin{enumerate}
 \item Le réécrire en utilisant des comportements
-\item Modifier le contrat de 1. de sorte que les comportements ne
+\item Modifier le contrat de 1 de sorte que les comportements ne
   soient pas disjoints. Excepté cette propriété, tout le reste devrait
   être correctement prouvé
-\item Modifier le contrat de 1. de sorte que les comportements ne
+\item Modifier le contrat de 1 de sorte que les comportements ne
   soient pas complets, puis ajouter un nouveau comportement pour le
   rendre de nouveau complet
-\item Modifier la fonction de 1. de façon à accepter la valeur
+\item Modifier la fonction de 1 de façon à accepter la valeur
   \CodeInline{NULL} pour les pointeurs d'entrées, si les deux pointeurs
   sont nuls, retourner  \CodeInline{INT\_MIN}, si l'un seulement est
   nul, retourner l'autre valeur, sinon retourner le maximum des deux

--- a/french/function-contract/contract.tex
+++ b/french/function-contract/contract.tex
@@ -1,7 +1,5 @@
 Le principe d'un contrat de fonction est de poser les conditions selon
 lesquelles la fonction s'exécutera. On distinguera deux parties :
-
-
 \begin{itemize}
 \item \textbf{la précondition}, c'est-à-dire ce que doit assurer le code
       appelant à propos des variables passées en paramètres et de l'état de
@@ -15,9 +13,6 @@ lesquelles la fonction s'exécutera. On distinguera deux parties :
 Ces propriétés sont exprimées en langage ACSL dont la syntaxe est relativement
 simple pour qui a déjà fait du C, puisqu'elle reprend la syntaxe des expressions
 booléennes du C. Cependant, elle ajoute également :
-
-
-
 \begin{itemize}
 \item certaines constructions et connecteurs logiques qui ne sont pas présents
 originellement en C pour faciliter l'écriture ;
@@ -225,7 +220,7 @@ un clic droit sur le nom de la fonction et « \textit{Prove function annotations
 
 
 
-\image{1-abs-2.png}[Lancer la vérification de abs avec WP]
+\image{1-abs-2.png}
 
 
 Nous pouvons voir que les cercles bleus deviennent des pastilles vertes,
@@ -235,9 +230,9 @@ et pas sur le nom de la fonction.
 
 
 
-Mais le code est-il vraiment sans erreur pour autant ? WP nous permet de nous
+Mais le code est-il vraiment sans erreurs pour autant ? WP nous permet de nous
 assurer que le code répond à la spécification, mais il ne fait pas de contrôle
-d'erreur à l'exécution (\textit{runtime error}, abrégé RTE) si nous le demandons
+d'erreur à l'exécution (\textit{runtime error}, abrégé RTE) si nous ne le demandons
 pas. Un autre \textit{plugin} de Frama-C, appelé sobrement RTE, peut être
 utilisé pour générer des annotations ACSL qui peuvent ensuite être vérifiées par
 d'autres \textit{plugins}.
@@ -268,7 +263,7 @@ contrôles par un clic droit sur le nom de la fonction puis
 
 
 \begin{Information}
-  A partir de ce point du tutoriel, \CodeInline{-wp-rte} devra toujours être
+  À partir de ce point du tutoriel, \CodeInline{-wp-rte} devra toujours être
   activé pour traiter les exemples, sauf indication contraire.
 \end{Information}
 
@@ -289,7 +284,7 @@ que -\CodeInline{INT\_MIN} ($-2^{31}$) > \CodeInline{INT\_MAX} ($2^{31}-1$).
 
 
 \begin{Information}
-Il est bon de noter que le risque de dépassement est pour nous réel car nos
+Il est bon de noter que le risque de dépassement est pour nous réel, car nos
 machines (dont Frama-C détecte la configuration) fonctionne en
 \externalLink{complément à deux}{https://fr.wikipedia.org/wiki/Compl\%C3\%A9ment\_\%C3\%A0\_deux}
 pour lequel le dépassement n'est pas défini par la norme C.
@@ -338,9 +333,6 @@ en supposant que $S_3$ est vraie, pour laquelle nous n'avons actuellement pas
 
 La couleur orange nous signale qu'aucun prouveur n'a pu déterminer si la
 propriété est vérifiable. Les deux raisons peuvent être :
-
-
-
 \begin{itemize}
 \item qu'il n'a pas assez d'information pour le déterminer ;
 \item que malgré toutes ses recherches, il n'a pas pu trouver un résultat à
@@ -613,12 +605,9 @@ frama-c-gui your-file.c -wp
 
 Lorsque la preuve que la fonction est conforme à son contrat est établie, lancer
 la commande :
-
 \begin{CodeBlock}{bash}
 frama-c-gui your-file.c -wp -wp-rte
 \end{CodeBlock}
-
-
 qui devrait échouer. Adapter le contrat en ajoutant la bonne précondition.
 
 
@@ -643,12 +632,9 @@ frama-c-gui your-file.c -wp
 
 Lorsque la preuve que la fonction est conforme à son contrat est établie, lancer
 la commande :
-
 \begin{CodeBlock}{bash}
 frama-c-gui your-file.c -wp -wp-rte
 \end{CodeBlock}
-
-
 qui devrait échouer. Adapter le contrat en ajoutant la bonne précondition.
 
 
@@ -679,7 +665,7 @@ assertions dans la fonction main.
 
 
 Écrire la postcondition de la fonction suivante qui retourne le nombre de
-jours en fonction du mois reçu en entrée (NB: nous considérons que le mois
+jours en fonction du mois reçu en entrée (NB : nous considérons que le mois
 reçu est entre 1 et 12), pour février, nous considérons uniquement le cas
 où il a 28 jours, nous verrons plus tard comment régler ce problème :
 
@@ -730,7 +716,7 @@ Cette fonction reçoit deux valeurs d'angle en entrée et retourne
 la valeur du dernier angle composant le triangle correspondant en se
 reposant sur la propriété que la somme des angles d'un triangle vaut
 180 degrés. Écrire la postcondition qui exprime que la somme des trois
-angle vaut 180.
+angles vaut 180.
 
 
 \CodeBlockInput[5]{c}{ex-5-last-angle.c}

--- a/french/function-contract/contract.tex
+++ b/french/function-contract/contract.tex
@@ -500,7 +500,7 @@ implémentation est prouvée :
 
 
 Nous pouvons également vérifier qu'une fonction qui appellerait \CodeInline{abs}
-assure bien la précondition qu'elle impose :
+satisfait bien la précondition qu'elle impose :
 
 
 

--- a/french/function-contract/contract.tex
+++ b/french/function-contract/contract.tex
@@ -310,7 +310,7 @@ pour les pastilles : vert + marron et orange.
 
 
 
-La couleur vert + marron nous indique que la preuve a été effectuée mais
+La couleur verte et marron nous indique que la preuve a été effectuée, mais
 qu'elle dépend potentiellement de propriétés pour lesquelles ce n'est pas le
 cas.
 
@@ -324,8 +324,8 @@ cette propriété puisqu'elle n'existait pas.
 
 
 
-En effet, lorsque WP transmet une obligation de preuve à un prouveur automatique,
-il transmet deux types de propriétés : $G$, le but, la propriété
+En effet, lorsque WP transmet une condition de vérification à un prouveur
+automatique, il transmet deux types de propriétés : $G$, le but, la propriété
 que l'on cherche à prouver, et $S_1$ ... $S_n$ les diverses suppositions que l'on
 peut faire à propos de l'état du programme au point où l'on cherche à vérifier $G$.
 Cependant, il ne reçoit pas, en retour, quelles propriétés ont été utilisées par
@@ -350,10 +350,10 @@ dans le volet de WP.
 
 
 Dans le volet inférieur, nous pouvons sélectionner l'onglet « \textit{WP Goals} »,
-celui-ci nous affiche la liste des obligations de preuve et pour chaque
+celui-ci nous affiche la liste des conditions de vérification et pour chaque
 prouveur indique un petit logo si la preuve a été tentée et si elle a été
 réussie, échouée ou a rencontré un \textit{timeout} (logo avec les ciseaux).
-Pour voir la totalité des obligations de preuves, il
+Pour voir la totalité des conditions de vérification, il
 faut s'assurer que « \textit{All Results} » est bien sélectionné dans le champ encadré
 dans la capture.
 
@@ -362,8 +362,8 @@ dans la capture.
 \image{1-abs-5.png}
 
 
-Le tableau est découpé comme suit, en première colonne nous avons le nom de la
-fonction où se trouve le but à prouver. En seconde colonne nous trouvons le nom
+Le tableau est découpé comme suit, en première colonne, nous avons le nom de la
+fonction où se trouve le but à prouver. En seconde colonne, nous trouvons le nom
 du but. Ici par exemple notre postcondition nommée est estampillée
 « postcondition 'positive\textit{value,function}result' », nous pouvons d'ailleurs noter
 que lorsqu'une propriété est sélectionnée dans le tableau, elle est également
@@ -395,7 +395,7 @@ nous pouvons voir ceci (si ce n'est pas le cas, il faut s'assurer que
 \image{1-abs-6.png}
 
 
-C'est l'obligation de preuve que génère WP par rapport à notre propriété et
+C'est la condition de vérification que génère WP par rapport à notre propriété et
 notre programme, il n'est pas nécessaire de comprendre tout ce qu'il s'y passe,
 juste d'avoir une idée globale. Elle contient (dans la partie « \textit{Assume} ») les
 suppositions que nous avons pu donner et celles que WP a pu déduire des
@@ -419,22 +419,22 @@ pas appel aux prouveurs.
 Lorsque les prouveurs automatiques ne parviennent pas à assurer que nos
 propriétés sont bien vérifiées, il est parfois difficile de comprendre
 pourquoi. En effet, les prouveurs sont généralement incapables de nous
-répondre autre chose que « oui », « non » ou « inconnu », ils sont pas
+répondre autre chose que « oui », « non » ou « inconnu », ils ne sont pas
 incapables d'extraire le « pourquoi » d'un « non » ou d'un « inconnu ». Il
 existe des outils qui
 sont capables d'explorer les arbres de preuve pour en extraire ce type
 d'information, Frama-C n'en possède pas à l'heure actuelle. La lecture des
-obligations de preuve peut parfois nous aider, mais cela demande un peu
+conditions de vérification peut parfois nous aider, mais cela demande un peu
 d'habitude pour pouvoir les déchiffrer facilement. Finalement, le meilleur
 moyen de comprendre la raison d'un échec est d'effectuer la preuve de manière
 interactive avec Coq. En revanche, il faut déjà avoir une certaine habitude de
-ce langage pour ne pas être perdu devant les obligations de preuve générées par
+ce langage pour ne pas être perdu devant les conditions de vérification générées par
 WP, étant donné que celles-ci encodent les éléments de la sémantique de C, ce
 qui rend le code souvent indigeste.
 
 
 
-Si nous retournons dans notre tableau des obligations de preuve (bouton
+Si nous retournons dans notre tableau des conditions de vérification (bouton
 encadré en rouge dans la capture d'écran précédente), nous pouvons donc voir
 que les hypothèses n'ont pas suffi aux prouveurs pour déterminer que la
 propriété  « absence de débordement » est vraie (et nous l'avons dit : c'est
@@ -554,8 +554,9 @@ de même que « vrai » est vrai. Donc tout est vrai.
 
 
 
-En prenant le programme modifié, nous pouvons d'ailleurs regarder les obligations
-de preuve générées par WP pour l'appel fautif et l'appel prouvé par conséquent :
+En prenant le programme modifié, nous pouvons d'ailleurs regarder les conditions
+de vérification générées par WP pour l'appel fautif et l'appel prouvé par
+conséquent :
 
 
 
@@ -670,7 +671,7 @@ frama-c-gui your-file.c -wp
 \end{CodeBlock}
 
 
-Toutes les obligations de preuve devraient être prouvées, y compris les
+Toutes les conditions de vérification devraient être prouvées, y compris les
 assertions dans la fonction main.
 
 

--- a/french/function-contract/contract.tex
+++ b/french/function-contract/contract.tex
@@ -3,10 +3,10 @@ lesquelles la fonction s'exécutera. On distinguera deux parties :
 
 
 \begin{itemize}
-\item \textbf{la précondition}, c'est-à-dire ce que doit respecter le code
+\item \textbf{la précondition}, c'est-à-dire ce que doit assurer le code
       appelant à propos des variables passées en paramètres et de l'état de
       la mémoire globale pour que la fonction s'exécute correctement ;
-\item \textbf{la postcondition}, c'est-à-dire ce que s'engage à respecter la
+\item \textbf{la postcondition}, c'est-à-dire ce que s'engage à fournir la
       fonction en retour à propos de l'état de la mémoire et de la valeur de
       retour.
 \end{itemize}
@@ -508,7 +508,7 @@ implémentation est prouvée :
 
 
 Nous pouvons également vérifier qu'une fonction qui appellerait \CodeInline{abs}
-respecte bien la précondition qu'elle impose :
+assure bien la précondition qu'elle impose :
 
 
 
@@ -610,7 +610,7 @@ frama-c-gui your-file.c -wp
 \end{CodeBlock}
 
 
-Lorsque la preuve que la fonction respecte son contrat est établie, lancer
+Lorsque la preuve que la fonction est conforme à son contrat est établie, lancer
 la commande :
 
 \begin{CodeBlock}{bash}
@@ -640,7 +640,7 @@ frama-c-gui your-file.c -wp
 \end{CodeBlock}
 
 
-Lorsque la preuve que la fonction respecte son contrat est établie, lancer
+Lorsque la preuve que la fonction est conforme à son contrat est établie, lancer
 la commande :
 
 \begin{CodeBlock}{bash}
@@ -694,7 +694,7 @@ frama-c-gui your-file.c -wp
 \end{CodeBlock}
 
 
-Lorsque la preuve que la fonction respecte son contrat est établie, lancer
+Lorsque la preuve que la fonction est conforme à contrat est établie, lancer
 la commande :
 
 \begin{CodeBlock}{bash}
@@ -743,7 +743,7 @@ frama-c-gui your-file.c -wp
 \end{CodeBlock}
 
 
-Lorsque la preuve que la fonction respecte son contrat est établie, lancer
+Lorsque la preuve que la fonction est conforme à son contrat est établie, lancer
 la commande :
 
 \begin{CodeBlock}{bash}

--- a/french/function-contract/modularity.tex
+++ b/french/function-contract/modularity.tex
@@ -36,7 +36,7 @@ Nous découpons en mettant le contrat de la fonction dans le \textit{header}. Le
 but est de pouvoir importer la spécification en même temps que la déclaration
 celle-ci lorsque nous aurons besoin de la fonction dans un autre fichier. En
 effet, WP en aura besoin pour montrer que les appels à cette
-fonction sont valides. D'abord pour prouver que la précondition est respectée
+fonction sont valides. D'abord pour prouver que la précondition est satisfaite
 (et donc que l'appel est légal) et ensuite pour savoir ce qu'il peut apprendre
 en retour (à savoir la postcondition) afin de pouvoir l'utiliser pour prouver
 la fonction appelante.

--- a/french/function-contract/modularity.tex
+++ b/french/function-contract/modularity.tex
@@ -44,7 +44,7 @@ la fonction appelante.
 
 
 Nous pouvons créer un fichier sous le même formatage pour la fonction \CodeInline{max}.
-Dans les deux cas, nous pouvons ré-ouvrir le fichier source (pas besoin de
+Dans les deux cas, nous pouvons rouvrir le fichier source (pas besoin de
 spécifier les fichiers \textit{headers} dans la ligne de commande) avec Frama-C et
 remarquer que la spécification est bien associée à la fonction et que nous
 pouvons la prouver.
@@ -59,7 +59,7 @@ Maintenant, nous pouvons préparer le terrain pour la fonction \CodeInline{max\_
 
 
 
-et dans le source :
+et dans le fichier source :
 
 
 
@@ -100,7 +100,7 @@ Finalement, le lecteur pourra essayer de spécifier la fonction \CodeInline{max\
 
 
 
-La spécification peut ressembler à ceci:
+La spécification peut ressembler à ceci :
 
 
 
@@ -118,7 +118,7 @@ La spécification peut ressembler à ceci:
 
 Spécifier la fonction année bissextile qui retourne vrai si l'année reçue
 en entrée est bissextile. Utiliser cette fonction pour compéter la fonction
-jours du mois de façon à retourner le nombre de jour du mois reçu en entrée,
+jours du mois de façon à retourner le nombre de jours du mois reçu en entrée,
 incluant le bon comportement lorsque le mois en question est février et que
 l'année est bissextile.
 
@@ -194,7 +194,7 @@ doit ensuite faire usage de cette fonction pour calculer le rendu de
 monnaie.
 
 
-Écrire le code de ces fonctions et leur spécification, et prouver la
+Écrire le code de ces fonctions et leur spécification puis prouver la
 correction. Notons que le code ne devrait pas faire usage de boucles
 puisque nous ne savons pas encore les traiter.
 

--- a/french/function-contract/well-specified.tex
+++ b/french/function-contract/well-specified.tex
@@ -103,7 +103,7 @@ et nous obtenons le résultat suivant dans l'interface graphique :
 Nous pouvons voir une pastille orange et rouge à côté de la précondition de la
 fonction, qui signifie que s'il existe un appel atteignable à la fonction dans
 le programme, la précondition sera nécessairement violée lors de cet appel ; et
-une pastille rouge dans la liste des obligations de preuve, indiquant qu'un
+une pastille rouge dans la liste des conditions de vérification, indiquant qu'un
 prouveur a réussi à montrer que la précondition est incohérente.
 
 

--- a/french/function-contract/well-specified.tex
+++ b/french/function-contract/well-specified.tex
@@ -5,7 +5,7 @@ C'est certainement notre tâche la plus difficile. En soi, la programmation est
 déjà un effort consistant à écrire des algorithmes qui répondent à notre
 besoin. La spécification nous demande également de faire ce travail, la
 différence est que nous ne nous occupons plus de préciser la manière de répondre
-au besoin mais le besoin lui-même. Pour prouver que la réalisation implémente
+au besoin, mais le besoin lui-même. Pour prouver que la réalisation implémente
 bien ce que nous attendons, il faut donc être capable de décrire précisément le
 besoin.
 
@@ -52,7 +52,7 @@ quant à la spécification :
 Même si elle est correcte, notre spécification est trop permissive. Il faut que nous
 soyons plus précis.
 Nous attendons du résultat non seulement qu'il soit supérieur ou égal à nos
-deux paramètres mais également qu'il soit exactement l'un des deux :
+deux paramètres, mais également qu'il soit exactement l'un des deux :
 
 
 
@@ -114,7 +114,7 @@ nous corrigeons la précondition de cette façon :
 \image{2-smoke-success}
 
 
-cela ne signifie pas que la précondition est nécessairement cohérente, juste
+Cela ne signifie pas que la précondition est nécessairement cohérente, juste
 qu'aucun prouveur n'a été capable de montrer qu'elle est incohérente.
 
 
@@ -150,7 +150,7 @@ le moment seulement vérifiable sans la vérification des RTEs) :
 
 Ici, nous introduisons une première fonction logique fournie de base par
 ACSL : \CodeInline{\textbackslash{}old}, qui permet de parler de l'ancienne
-valeur d'un élément. Ce que nous dit donc la spécification c'est « la fonction
+valeur d'un élément. Ce que nous dit donc la spécification est « la fonction
 doit assurer que \CodeInline{*a} soit égal à l'ancienne valeur (au sens : la
 valeur avant l'appel) de \CodeInline{*b} et inversement ».
 
@@ -176,7 +176,7 @@ Par exemple, nous pourrions écrire :
 
 
 En plus des labels que nous pouvons nous-mêmes créer, il existe 6 labels
-qu'ACSL nous propose par défaut:
+qu'ACSL nous propose par défaut :
 
 
 
@@ -207,7 +207,7 @@ disponibles que dans le contexte de boucles (dont nous parlerons plus loin dans
 le tutoriel).
 
 
-Notons qu'il est important de s'assurer que l'on utilise \CodeInline{\textbackslash{}old} at
+Notons qu'il est important de s'assurer que l'on utilise \CodeInline{\textbackslash{}old} et
 \CodeInline{\textbackslash{}at} pour des valeurs qui ont du sens. C'est pourquoi par
 exemple dans un contrat, toutes les valeurs reçues en entrée sont placées dans un
 appel à \CodeInline{\textbackslash{}old} par Frama-C lorsqu'elles sont utilisées dans
@@ -221,11 +221,11 @@ la postcondition, chaque pointeur se trouve dans un appel à \CodeInline{\textba
 \image{2-old-swap}
 
 
-Pour la fonction built-in \CodeInline{\textbackslash{}at}, nous devons plus
+Pour la fonction \CodeInline{\textbackslash{}at}, nous devons plus
 explicitement faire attention à cela. En particulier, le label transmis en entrée
 doit avoir un sens par rapport à la portée de la variable que l'on lui transmet.
 Par exemple, dans le programme suivant, Frama-C détecte que nous demandons la valeur
-de la variable \CodeInline{x} à un point du programme où elle n'existe pas:
+de la variable \CodeInline{x} à un point du programme où elle n'existe pas :
 
 
 \CodeBlockInput[5][9]{c}{at-2.c}
@@ -237,7 +237,7 @@ de la variable \CodeInline{x} à un point du programme où elle n'existe pas:
 Cependant, dans certains cas, tout ce que nous pouvons obtenir est un échec de
 la preuve, parce que déterminer si la valeur existe ou non à un label particulier
 ne peut être fait par une analyse purement syntaxique. Par exemple, si la variable
-est déclarée mais pas définie, ou si nous demandons la valeur d'une zone mémoire
+est déclarée, mais pas définie, ou si nous demandons la valeur d'une zone mémoire
 pointée :
 
 
@@ -273,7 +273,7 @@ précises.
 
 
 Si nous essayons de prouver le fonctionnement de \CodeInline{swap} (en activant
-la vérification des RTE), notre postcondition est bien vérifiée mais WP nous
+la vérification des RTE), notre postcondition est bien vérifiée, mais WP nous
 indique qu'il y a un certain nombre de possibilités de \textit{runtime-error}. Ce qui
 est normal, car nous n'avons pas précisé à WP que les pointeurs que nous
 recevons en entrée de fonction sont valides.
@@ -290,7 +290,7 @@ reçoit un pointeur en entrée :
 
 
 À partir de là, les déréférencements qui sont effectués par la suite sont
-acceptés car la fonction demande à ce que les pointeurs d'entrée soient
+acceptés, car la fonction demande à ce que les pointeurs d'entrée soient
 valides.
 
 
@@ -309,7 +309,7 @@ de \CodeInline{\textbackslash{}valid} sous le nom \CodeInline{\textbackslash{}va
 celui-ci assure qu'il est uniquement nécessaire que le pointeur puisse
 être déréférencé en lecture et pas forcément en écriture, pour pouvoir
 réaliser l'opération de lecture. Cette subtilité est due au fait qu'en C, le
-\textit{downcast} de pointeur vers un élément \CodeInline{const} est très facile à faire mais
+\textit{downcast} de pointeur vers un élément \CodeInline{const} est très facile à faire, mais
 n'est pas forcément légal.
 
 
@@ -424,7 +424,7 @@ différent du pointeur \CodeInline{b}. Or, si les pointeurs sont égaux,
 \item la propriété \CodeInline{*a == \textbackslash{}old(*a) + *b} signifie en fait
 \CodeInline{*a == \textbackslash{}old(*a) + *a}, ce qui ne peut être vrai que si l'ancienne valeur
 pointée par \CodeInline{a} était 0, ce qu'on ne sait pas,
-\item la propriété \CodeInline{*b == \textbackslash{}old(*b)} n'est pas validée car potentiellement,
+\item la propriété \CodeInline{*b == \textbackslash{}old(*b)} n'est pas validée, car potentiellement,
 nous la modifions.
 \end{itemize}
 
@@ -497,7 +497,7 @@ et notre matériel. Cela concerne principalement nos préconditions. Par exemple
 la fonction valeur absolue n'a, au fond, pas  vraiment de précondition à
 satisfaire : c'est la machine cible qui détermine qu'une condition supplémentaire
 doit être vérifiée en raison du complément à deux. Comme nous le verrons dans le
-chapitre \ref{l1:proof-methodologies}, vérifier l'absence de {\em runtime errors}
+chapitre \ref{l1:proof-methodologies}, vérifier l'absence de \emph{runtime-errors}
 peut aussi impacter nos postconditions, pour l'instant laissons cela de côté.
 
 
@@ -656,11 +656,9 @@ exemple :
 
 Nous pouvons l'utiliser pour exprimer que l'ensemble des valeurs d'entrée et
 de sortie est le même. Cependant, ce n'est pas la seule chose à prendre en
-compte car un ensemble ne contient qu'une occurrence de chaque valeur. Donc,
+compte, car un ensemble ne contient qu'une occurrence de chaque valeur. Donc,
 si \CodeInline{*a == *b == 1}, alors \CodeInline{\{ *a, *b \} == \{ 1 \}}.
-Par conséquent nous devons considérer trois autres cas particuliers:
-
-
+Par conséquent, nous devons considérer trois autres cas particuliers :
 \begin{itemize}
 \item toutes les valeurs d'origine sont les mêmes ;
 \item deux valeurs d'origine sont les mêmes, la dernière est plus grande ;

--- a/french/function-contract/well-specified.tex
+++ b/french/function-contract/well-specified.tex
@@ -78,7 +78,7 @@ FAUX :
 
 Si nous demandons à WP de prouver cette fonction. Il l'acceptera sans rechigner,
 car la propriété que nous lui donnons comme précondition est nécessairement fausse.
-Par contre, nous aurons bien du mal à lui donner une valeur en entrée qui respecte
+Par contre, nous aurons bien du mal à lui donner une valeur en entrée qui satisfait
 la précondition.
 
 
@@ -494,11 +494,11 @@ préalablement s'accorder sur une spécification textuelle par exemple).
 Une fois que le contrat est posé, alors seulement, nous nous intéressons aux
 spécifications dues au fait que nous sommes soumis aux contraintes de notre langage
 et notre matériel. Cela concerne principalement nos préconditions. Par exemple,
-la fonction valeur absolue n'a, au fond, pas  vraiment de précondition à respecter,
-c'est la machine cible qui détermine qu'une condition supplémentaire doit être
-respectée en raison du complément à deux. Comme nous le verrons dans le chapitre
-\ref{l1:proof-methodologies}, vérifier l'absence de runtime errors peut aussi
-impacter nos postconditions, pour l'instant laissons cela de côté.
+la fonction valeur absolue n'a, au fond, pas  vraiment de précondition à
+satisfaire : c'est la machine cible qui détermine qu'une condition supplémentaire
+doit être vérifiée en raison du complément à deux. Comme nous le verrons dans le
+chapitre \ref{l1:proof-methodologies}, vérifier l'absence de {\em runtime errors}
+peut aussi impacter nos postconditions, pour l'instant laissons cela de côté.
 
 
 \levelThreeTitle{Exercices}

--- a/french/introduction.tex
+++ b/french/introduction.tex
@@ -5,11 +5,11 @@
   propriétés).
 
   Si vous trouvez des erreurs, n'hésitez pas à créer une \textit{issue} ou
-  une \textit{pull request} sur:
+  une \textit{pull request} sur :
 
   \externalLink{https://github.com/AllanBlanchard/tutoriel\_wp}{https://github.com/AllanBlanchard/tutoriel_wp}
 
-  ou à poster sur le sujet de la bêta sur Zeste de Savoir:
+  ou à poster sur le sujet de la bêta sur Zeste de Savoir :
 
   \externalLink{https://zestedesavoir.com/forums/sujet/7725/introduction-a-la-preuve-de-programmes-c-avec-frama-c-et-son-greffon-wp/}{https://zestedesavoir.com/forums/sujet/7725/introduction-a-la-preuve-de-programmes-c-avec-frama-c-et-son-greffon-wp/}
 \end{Warning}
@@ -46,7 +46,7 @@ Les scripts Coq devraient fonctionner au moins de la version 8.7.2 à 8.11.2.
 
 \horizontalLine
 
-Le seul pré-requis pour ce cours est d'avoir une connaissance basique du
+Le seul prérequis pour ce cours est d'avoir une connaissance basique du
 langage C, au moins jusqu'à la notion de pointeur.
 
 

--- a/french/introduction.tex
+++ b/french/introduction.tex
@@ -67,13 +67,13 @@ base de connaissances) très conséquent.
 
 
 De plus, de très nombreux systèmes reposent sur des quantités phénoménales de
-code historiquement écrit en C, qu'il faut maintenir et corriger car ils
+code historiquement écrit en C, qu'il faut maintenir et corriger, car ils
 coûteraient bien trop chers à re-développer.
 
 
 
 Mais toute personne qui a déjà codé en C sait également que c'est un langage
-très difficile à maîtriser parfaitement. Les raisons sont multiples mais les
+très difficile à maîtriser parfaitement. Les raisons sont multiples, mais les
 ambiguïtés présentes dans sa norme et la permissivité extrême qu'il offre au
 développeur, notamment en ce qui concerne les accès à la mémoire, font que
 créer un programme C robuste est très difficile même pour un programmeur
@@ -99,7 +99,7 @@ qu'aucun problème ne peut apparaître à l'exécution.
 
 L'objet de ce tutoriel est d'utiliser Frama-C, un logiciel développé au
 CEA List, et WP, son greffon de preuve déductive, pour s'initier à la preuve
-de programmes C. Au delà de l'usage de l'outil en lui-même, le but de ce tutoriel
+de programmes C. Au-delà de l'usage de l'outil en lui-même, le but de ce tutoriel
 est de vous convaincre qu'il est possible d'écrire des programmes sans erreurs de
 programmation, mais également de sensibiliser à des notions simples
 permettant de mieux comprendre et de mieux écrire les programmes.
@@ -125,8 +125,7 @@ Ainsi qu'aux validateurs qui ont encore permis d'améliorer la qualité de ce tu
 
 Un grand merci à Jens Gerlach pour son aide lors de la traduction anglaise du tutoriel.
 
-Merci finalement aux reviewers occasionnels sur GitHub:
-
+Merci finalement aux reviewers occasionnels sur GitHub :
 \begin{itemize}
   \item \externalLink{Alex Lyr}{https://github.com/AlexLyrr}
   \item \externalLink{Rafael Bachmann}{https://github.com/barafael}
@@ -140,7 +139,6 @@ Merci finalement aux reviewers occasionnels sur GitHub:
   \item \externalLink{Ricardo M. Correia}{https://github.com/wizeman}
   \item \externalLink{Basile Desloges}{https://github.com/zilbuz}
 \end{itemize}
-
 pour leurs relectures et corrections.
 
 \end{Information}

--- a/french/program-proof-and-our-tool/frama-c.tex
+++ b/french/program-proof-and-our-tool/frama-c.tex
@@ -167,7 +167,7 @@ qui est disponible sur Opam ou sur leur site web
 
 
 Après décompression de l'archive disponible ici :
-\externalLink{http://frama-c.com/download.html}{http://frama-c.com/download.html} (Source distribution).
+\externalLink{https://frama-c.com/html/get-frama-c.html}{https://frama-c.com/html/get-frama-c.html} (Source distribution).
 Il faut se rendre dans le dossier et exécuter la commande :
 
 

--- a/french/program-proof-and-our-tool/frama-c.tex
+++ b/french/program-proof-and-our-tool/frama-c.tex
@@ -32,9 +32,9 @@ L'analyse que nous allons utiliser ici est fournie par un plugin appelé WP pour
 \textit{Weakest Precondition}, un plugin de vérification déduction. Il implémente
 la technique dont nous avons parlé plus tôt :
 à partir des annotations ACSL et du code source, le plugin génère ce que nous
-appelons des obligations de preuves, qui sont des formules logiques dont nous
-devons vérifier si elles sont vraies ou fausses (on parle de « satisfiabilité »).
-Cette vérification peut être faite de manière
+appelons des conditions de vérification (ou obligations de preuves), qui sont
+des formules logiques dont nous devons vérifier si elles sont vraies ou fausses
+(on parle de « satisfiabilité »). Cette vérification peut être faite de manière
 manuelle ou automatique, ici nous n'utiliserons que des outils automatiques.
 
 
@@ -51,7 +51,7 @@ OCamlPro.
 \levelThreeTitle{Installation}
 
 
-Frama-C est un logiciel développé sous Linux et OSX. Son support est donc bien
+Frama-C est un logiciel développé sous Linux et macOS. Son support est donc bien
 meilleur sous ces derniers. Il existe quand même de quoi faire une installation
 sous Windows et en théorie l'utilisation sera sensiblement la même que sous
 Linux, mais :
@@ -385,7 +385,7 @@ Pourquoi aurait-on besoin d'un tel outil ? Il se peut parfois que les
 propriétés que nous voulons prouver soient trop complexes pour un prouveur
 automatique, typiquement lorsqu'elles nécessitent des raisonnements par
 induction avec des choix minutieux à chaque étape. Auquel cas, WP pourra
-générer des obligations de preuve traduites en Coq et nous laisser écrire
+générer des conditions de vérification traduites en Coq et nous laisser écrire
 la preuve en question.
 
 

--- a/french/program-proof-and-our-tool/frama-c.tex
+++ b/french/program-proof-and-our-tool/frama-c.tex
@@ -349,7 +349,7 @@ De nouveaux prouveurs peuvent être installés n'importe quand après
 l'installation de Frama-C. Cependant, la liste des prouveurs vus par Why3
 doit être mise à jour :
 \begin{CodeBlock}{bash}
-why3 config --full-config
+why3 config detect
 \end{CodeBlock}
 puis activée dans Frama-C. Dans le panneau latéral, dans la partie WP,
 cliquons sur « Provers... » :

--- a/french/program-proof-and-our-tool/frama-c.tex
+++ b/french/program-proof-and-our-tool/frama-c.tex
@@ -55,9 +55,6 @@ Frama-C est un logiciel développé sous Linux et macOS. Son support est donc bi
 meilleur sous ces derniers. Il existe quand même de quoi faire une installation
 sous Windows et en théorie l'utilisation sera sensiblement la même que sous
 Linux, mais :
-
-
-
 \begin{Warning}
 \begin{itemize}
 \item le tutoriel présentera le fonctionnement sous Linux et l'auteur n'a pas
@@ -89,14 +86,16 @@ apt-get/yum install frama-c
 
 
 
-Par contre, ces dépôts ne sont pas systématiquement à jour. En soi, ce n'est pas très gênant car il n'y a pas de nouvelle version de Frama-C tous les deux mois, mais il est tout de même bon de le savoir.
+Par contre, ces dépôts ne sont pas systématiquement à jour. En soi, ce n'est pas
+très gênant, car il n'y a pas de nouvelle version de Frama-C tous les deux mois,
+mais il est tout de même bon de le savoir.
 
 
 
 Les informations pour vérifier l'installation sont données dans la sous-section « Vérifier l'installation ».
 
 
-\levelFiveTitle{Via opam}
+\levelFiveTitle{Via Opam}
 
 
 La deuxième solution consiste à passer par Opam, un gestionnaire de paquets
@@ -125,7 +124,7 @@ opam depext frama-c
 
 
 Si depext ne trouve pas les dépendances pour votre distribution, les paquets
-suivant doivent être présents sur votre système :
+suivants doivent être présents sur votre système :
 
 
 \begin{itemize}
@@ -160,7 +159,7 @@ Les informations pour vérifier l'installation sont données dans la sous-sectio
 
 Pour installer Frama-C via une compilation manuelle, les paquets indiqués dans la
 section Opam sont nécessaires (mis à part Opam lui-même bien sûr). Il faut
-également une version récente d'Ocaml et de son compilateur (y compris vers
+également une version récente d'OCaml et de son compilateur (y compris vers
 code natif). Il est aussi nécessaire d'installer Why3, en version 1.2.0,
 qui est disponible sur Opam ou sur leur site web
 (\externalLink{Why3}{http://why3.lri.fr/}).
@@ -181,12 +180,12 @@ autoconf && ./configure && make && sudo make install
 Les informations pour vérifier l'installation sont données dans la sous-section « Vérifier l'installation ».
 
 
-\levelFourTitle{OSX}
+\levelFourTitle{macOS}
 
 
-L'installation sur OSX passe par Homebrew et Opam. L'auteur n'ayant
-personnellement pas d'OSX, voici une honteuse paraphrase du guide
-d'installation de Frama-C pour OSX.
+L'installation sur macOS passe par Homebrew et Opam. L'auteur n'ayant
+personnellement pas de macOS, voici une honteuse paraphrase du guide
+d'installation de Frama-C pour macOS.
 
 
 
@@ -214,7 +213,7 @@ Pour l'interface graphique :
 
 
 
-Dépendances pour alt-ergo :
+Dépendances pour Alt-Ergo :
 
 
 
@@ -257,7 +256,7 @@ Les informations pour vérifier l'installation sont données dans la sous-sectio
 \levelThreeTitle{Vérifier l'installation}
 
 
-Pour vérifier votre installation, commençez par mettre ce code très simple dans
+Pour vérifier votre installation, commencez par mettre ce code très simple dans
 un fichier « main.c » :
 
 
@@ -321,10 +320,10 @@ frama-c-gui -gui-theme colorblind
 Cette partie est purement optionnelle, rien de ce qui est ici ne sera
 indispensable pendant le tutoriel. Cependant, lorsque l'on commence à
 s'intéresser vraiment à la preuve, il est possible de toucher assez rapidement
-aux limites du prouveur pré-intégré Alt-Ergo et d'avoir besoin d'autres
+aux limites du prouveur Alt-Ergo et d'avoir besoin d'autres
 prouveurs. Pour des propriétés simples, tous les prouveurs jouent à armes
 égales, pour des propriétés complexes, chaque prouveur à ses domaines de
-prédilecion.
+prédilection.
 
 \levelFourTitle{Why3}
 
@@ -347,16 +346,12 @@ efficaces et relativement complémentaires.
 
 
 De nouveaux prouveurs peuvent être installés n'importe quand après
-l'installation de Frama-C. Cependant la liste des prouveurs vus par Why3
+l'installation de Frama-C. Cependant, la liste des prouveurs vus par Why3
 doit être mise à jour :
-
-
 \begin{CodeBlock}{bash}
 why3 config --full-config
 \end{CodeBlock}
-
-
-puis activée dan Frama-C. Dans le panneau latéral, dans la partie WP,
+puis activée dans Frama-C. Dans le panneau latéral, dans la partie WP,
 cliquons sur « Provers... » :
 
 
@@ -376,7 +371,7 @@ de leur nom.
 
 Coq, développé par l'organisme de recherche Inria, est un assistant de
 preuve. C'est-à-dire que nous écrivons nous-même les preuves dans un
-langage dédié, et la plateforme se charge de vérifier (par typage) que
+langage dédié et la plateforme se charge de vérifier (par typage) que
 cette preuve est valide.
 
 
@@ -403,15 +398,3 @@ paquets, il peut arriver que celui-ci ait directement intégré Coq.
 
 
 Pour plus d'informations à propos de Coq et de son installation, voir \externalLink{The Coq Proof Assistant}{https://coq.inria.fr/}.
-
-
-Le support actuel de Coq dans Frama-C est déprécié mais toujours
-accessible. Comme nous fournissons dans ce tutoriel quelques scripts de preuve
-Coq qui peuvent être utilisés, nous fournissons ces instructions afin que
-ces scripts puissent être visionnés et testés par les utilisateurs. Pour lancer
-Frama-C avec le support de Coq, nous utilisons la commande :
-
-
-\begin{CodeBlock}{bash}
-  frama-c -wp-provers=native:coq
-\end{CodeBlock}

--- a/french/program-proof-and-our-tool/program-proof.tex
+++ b/french/program-proof-and-our-tool/program-proof.tex
@@ -39,7 +39,7 @@ difficulté réside donc dans le fait de choisir les bons tests.
 
 
 Le but de la preuve de programmes est de s'assurer que, quelle que soit l'entrée
-fournie au programme, si elle respecte la spécification, alors le programme
+fournie au programme, si elle est conforme à la spécification, alors le programme
 fera ce qui est attendu. Cependant, comme nous ne pouvons pas tout essayer, nous
 allons établir formellement, mathématiquement, la preuve que le logiciel ne
 peut exhiber que les comportements qui sont spécifiés et que les erreurs
@@ -396,7 +396,7 @@ $\{P\}$ $x$ $:=$ a $\{x = 42\}$
 
 
 Quelle est la précondition minimale pour que la postcondition $\{x = 42\}$
-soit respectée ? La règle nous dira que $P$ est $\{$a$=42\}$.
+soit vérifiée ? La règle nous dira que $P$ est $\{$a$=42\}$.
 
 
 

--- a/french/program-proof-and-our-tool/program-proof.tex
+++ b/french/program-proof-and-our-tool/program-proof.tex
@@ -59,7 +59,7 @@ their absence!
 
 
 
-Le test de programme peut être utilisé pour montrer la présence de bugs mais
+Le test de programme peut être utilisé pour montrer la présence de bugs, mais
 jamais pour montrer leur absence.
 
 
@@ -83,8 +83,6 @@ spécification. À cela s’ajoute la spécification de notre langage de
 programmation qui nous définit la manière correcte de l’utiliser. Chacun de
 ces aspects peut donner lieu à l’introduction de bugs, que nous pouvons
 séparer en trois catégories :
-
-
 \begin{itemize}
 \item le programme n’est pas conforme, ou son comportement non défini,
       d’après la spécification du langage (par exemple, le programme accède
@@ -103,7 +101,7 @@ séparer en trois catégories :
 \end{itemize}
 
 
-Chacune de ces catégories peut affecter la sûreté et/ou la sécurité de nos
+Chacune de ces catégories peut affecter la sûreté et la sécurité de nos
 programmes, qui ne sont pas des notions tout à fait équivalentes. Pour donner
 une idée de la différence qui existe entre ces deux notions, nous pouvons
 dire que dans le cas de la sécurité, on suppose qu’il existe une entité
@@ -123,8 +121,6 @@ Tout au long de ce tutoriel, nous montrerons comment prouver que les
 implémentations de nos programmes ne contiennent pas de bugs correspondant
 aux deux premières catégories définies plus haut, à savoir qu’ils sont
 conformes :
-
-
 \begin{itemize}
 \item à la spécification de notre langage ;
 \item à la spécification de ce que nous attendons d’eux.
@@ -139,7 +135,7 @@ demande de comprendre exactement le besoin auquel nous devons répondre.
 
 Nous pourrions dire avec cynisme que la preuve nous montre finalement que
 l’implémentation « ne contient aucun bug de plus que la spécification », et
-donc que nous traitons pas la troisième catégorie de bugs que nous avons
+donc que nous ne traitons pas la troisième catégorie de bugs que nous avons
 définie. Cependant, être sûr que le programme « ne contient aucun bug de
 plus que la spécification » est déjà un sacré pas en avant par rapport à
 savoir que le programme « ne contient pas beaucoup plus de bugs que la
@@ -148,7 +144,7 @@ dont nous nous débarrassons, bugs qui peuvent déjà sévèrement compromettre 
 sûreté et la sécurité de nos programmes. Ensuite, il existe également des
 techniques pour traiter la troisième catégorie de bugs, en analysant les
 spécifications en quête d’erreurs ou d’insuffisance. Par exemple, les
-techniques de model checking - vérification de modèles - permettent de
+techniques de \emph{model checking} - vérification de modèles - permettent de
 construire un modèle abstrait à partir d’une spécification et de produire
 un ensemble d’états accessibles du programme d’après le modèle. En
 caractérisant les états fautifs, nous sommes en mesure de déterminer si les
@@ -177,7 +173,7 @@ code correspond à ce que nous voulons exprimer. La technique que nous allons
 Le principe des analyses statiques est que nous n'exécuterons pas le programme
 pour nous assurer que son fonctionnement est correct, mais nous raisonnerons sur
 un modèle mathématique définissant l'ensemble des états qu'il peut atteindre.
-A l'inverse, les analyses dynamiques comme le test de programmes nécessitent
+À l'inverse, les analyses dynamiques comme le test de programmes nécessitent
 d'exécuter le code analysé. Il existe également des analyses dynamiques et
 formelles, comme de la génération automatique de tests ou encore des techniques
 de \textit{monitoring} de code qui pourront, par exemple, instrumenter un code
@@ -204,22 +200,19 @@ comportement de notre chronomètre est la suivante :
 Nous avons bien une modélisation du comportement de notre chronomètre avec
 différents états qu'il peut atteindre en fonction des actions qu'il subit.
 Cependant, nous n'avons pas modélisé comment ces états sont
-représentés dans le programme (est-ce une énumération ? une position précise
+représentés dans le programme (Est-ce une énumération ? Une position précise
 atteinte au sein du code ?), ni comment est modélisé le calcul du temps (une seule
 variable en secondes ? Plusieurs variables heures, minutes, secondes ?). Nous
 aurions donc bien du mal à spécifier des propriétés à propos de notre programme.
 Nous pouvons ajouter des informations :
-
-
-
 \begin{itemize}
-\item état arrêté à zéro : temps = 0s ;
-\item état en marche : temps > 0s ;
-\item état arrêté : temps > 0s.
+\item état arrêté à zéro : temps = 0 s ;
+\item état en marche : temps > 0 s ;
+\item état arrêté : temps > 0 s.
 \end{itemize}
 
 
-Ce qui nous donne déjà un modèle plus concret mais qui est toujours insuffisant
+Ce qui nous donne déjà un modèle plus concret, mais qui est toujours insuffisant
 pour poser des questions intéressantes à propos de notre système comme : « est-il
 possible que dans l'état arrêté, le temps continue de s'écouler ? ». Car nous
 n'avons pas modélisé l'écoulement du temps par le chronomètre.
@@ -237,7 +230,7 @@ Plus un modèle est concret, plus il décrit précisément le comportement de no
 programme. Le code source exprime le comportement plus précisément que notre
 diagramme, mais il est moins précis que le code de l'exécutable. Cependant, plus
 un modèle est précis, plus il est difficile d'avoir une vision globale du
-comportement qu'il définit. Notre diagramme est compréhensible en un coup d'oeil,
+comportement qu'il définit. Notre diagramme est compréhensible en un coup d'\oe{}il,
 le code demande un peu plus de temps, quant à l'exécutable ... Toute personne qui
 a déjà ouvert par erreur un exécutable avec un éditeur de texte sait que ce n'est
 pas très agréable à lire dans son ensemble\footnote{Il existe des analyses
@@ -275,9 +268,6 @@ par \externalLink{Tony Hoare}{https://fr.wikipedia.org/wiki/Charles_Antony_Richa
 en 1969 dans un article intitulé \textit{An Axiomatic Basis for
 Computer Programming} (une base axiomatique pour la programmation des
 ordinateurs). Cette méthode définit :
-
-
-
 \begin{itemize}
 \item des axiomes, qui sont des propriétés que nous admettons, comme \\
 « l'action “ne rien faire” ne change pas l'état du programme »,
@@ -317,10 +307,10 @@ Quand nous ne faisons rien, la postcondition est la même que la précondition.
 
 
 Tout au long de ce tutoriel, nous verrons la sémantique de diverses
-constructions (blocs conditionnels, boucles, etc ...) dans la logique de Hoare.
+constructions (blocs conditionnels, boucles, etc.) dans la logique de Hoare.
 Nous n'allons donc pas tout de suite rentrer dans ces détails puisque nous en
 aurons l'occasion plus tard. Il n'est pas nécessaire de mémoriser ces notions
-ni même de comprendre toute la théorie derrière mais il est toujours utile
+ni même de comprendre toute la théorie derrière, mais il est toujours utile
 d'avoir au moins une vague idée du fonctionnement de l'outil que nous
 utilisons.
 
@@ -342,7 +332,7 @@ commands, non-determinacy and formal derivation of programs}.
 
 
 
-Cette phrase contient pas mal de mots méchants mais le concept est en fait très
+Cette phrase contient pas mal de mots méchants, mais le concept est en fait très
 simple. Comme nous l'avons vu précédemment, la logique de Hoare donne des
 règles expliquant comment se comportent les actions d'un programme. Mais
 elle ne nous dit pas comment appliquer ces règles pour établir une preuve
@@ -351,14 +341,14 @@ complète du programme.
 
 
 Dijkstra reformule la logique de Hoare en expliquant comment, dans le triplet
-$\{P\}C\{Q\}$, l'instruction, ou le bloc d'instructions, $C$ transforme le
+$\{P\}C\{Q\}$, l'instruction ou le bloc d'instructions, $C$ transforme le
 prédicat $P$, en $Q$. Cette forme est appelée « raisonnement vers l'avant » ou
 \textit{forward-reasoning}. Nous calculons à partir d'une précondition et d'une ou
 plusieurs instructions, la plus forte postcondition que nous pouvons
 atteindre. Informellement, en considérant ce qui est reçu en entrée, nous
 calculons ce qui sera renvoyé au plus en sortie. Si la postcondition voulue
 est au plus aussi forte, alors nous avons prouvé qu'il n'y a pas de
-comportements non-voulus.
+comportements non voulus.
 
 
 

--- a/french/proof-methodologies.tex
+++ b/french/proof-methodologies.tex
@@ -44,7 +44,7 @@ même lorsque c'est trop difficile pour les solveurs SMT.
 
 
 Avec un peu d'expérience, il est possible de lire le contenu des
-obligations de preuve ou essayer de faire la preuve soi-même avec
+conditions de vérification ou essayer de faire la preuve soi-même avec
 l'assistant de preuve Coq pour voir si la preuve semble réalisable.
 Parfois, le prouveur a juste besoin de plus de temps, dans ce cas, nous
 pouvons augmenter (parfois beaucoup) le temps de \textit{timeout}. Bien

--- a/french/proof-methodologies/lemma-functions.tex
+++ b/french/proof-methodologies/lemma-functions.tex
@@ -1,9 +1,9 @@
 Les assertions nous permettent de donner des indices au générateur
-d'obligation de preuves pour les solveurs SMT obtiennent assez d'information
+de conditions de vérification pour les solveurs SMT obtiennent assez d'information
 pour produire la preuve dont nous avons besoin. Cependant, il est parfois
 difficile d'écrire une assertion qui créera exactement la propriété dont le
 solveur SMT a besoin pour déclencher le bon lemme (par exemple, puisque le
-générateur effectue des optimisations sur les obligations de preuve, ils peuvent
+générateur effectue des optimisations sur les conditions de vérification, ils peuvent
 légèrement la modifier, ainsi que le contexte de preuve). De plus, nous
 reposons sur des lemmes qui ont souvent besoin d'être prouvés en Coq, et pour
 cela nous avons besoin d'apprendre Coq.
@@ -31,13 +31,13 @@ invariant de boucle, nous procédons ... par induction. L'auteur de ce tutoriel
 aurait-il honteusement menti au lecteur pendant tout ce temps ?
 
 
-En fait non, et la raison est plutôt simple. Lorsque nous prouvons un
+En fait non. La raison est plutôt simple. Lorsque nous prouvons un
 invariant de boucle par induction en utilisant des solveurs SMT, ils n'ont pas
 besoin d'effectuer le raisonnement par induction eux-mêmes. Le travail qui
 consiste à séparer la preuve en deux sous-preuves, la première pour
 l'établissement de l'invariant (le cas de base de la preuve), et la seconde pour
 la préservation (le cas d'induction) est effectué par le générateur
-d'obligations de preuve. Par conséquent, quand les obligations de preuves sont
+de conditions de vérification. Par conséquent, quand les conditions de vérifications sont
 transmises aux solveurs SMT, ce travail n'est plus nécessaire.
 
 
@@ -75,12 +75,12 @@ plage donnée de taille $i$ avec $i < length$ ($length$ étant la taille de la
 plage complète) est globalement triée et montrons que si c'est le cas, alors la
 plage de taille $i+1$ est triée. C'est facile parce que, d'après notre
 précondition, nous savons que le $i^{ième}$ élément est supérieur ou égal au
-$(i-1)^{ième}$ élément, qui est lui même plus grand que tous les éléments qui
-précède.
+$(i-1)^{ième}$ élément, qui est lui-même plus grand que tous les éléments qui
+le précèdent.
 
 
 Comment pouvons-nous traduire cela en code fantôme ? Nous écrivons une boucle qui
-vas de $0$ (notre cas de base), à la fin \CodeInline{len} et nous fournissons
+va de $0$ (notre cas de base), à la fin \CodeInline{len} et nous fournissons
 un invariant montrant que le tableau est globalement trié depuis $0$ jusqu'à la
 cellule actuellement visitée. Nous ajoutons également une assertion pour aider le
 prouveur (qui nous dit que l'élément courant est plus grand que les éléments qui
@@ -92,9 +92,9 @@ précèdent) :
 
 
 
-Nous pouvons voir que toutes les obligations de preuve sont facilement
+Nous pouvons voir que toutes les conditions de vérification sont facilement
 vérifiées par les solveurs SMT, sans que cela ne nécessite d'écrire une preuve Coq
-ou un lemme. Les obligations de preuve respectivement créées pour
+ou un lemme. Les conditions de vérification respectivement créées pour
 l'établissement et la préservation de l'invariant correspondent aux deux cas que
 nous avions besoin dans notre preuve par induction :
 

--- a/french/proof-methodologies/lemma-functions.tex
+++ b/french/proof-methodologies/lemma-functions.tex
@@ -14,7 +14,7 @@ utilisées pour rendre tout cela plus prédictible et nous éviter d'utiliser
 l'assistant de preuve Coq. Tandis que ces techniques ne peuvent pas toujours
 être utilisées (et nous expliquerons quand cela n'est pas applicable), elles
 sont généralement efficaces pour obtenir de la preuve presque complètement
-automatiques. Cela repose sur l'usage de code fantôme.
+automatique. Cela repose sur l'usage de code fantôme.
 
 
 \levelThreeTitle{Preuve par induction}
@@ -136,7 +136,7 @@ preuve à nouveau, en instanciant les valeurs nécessaires.
 
 
 La manière de faire cela est d'utiliser une fonction, en utilisant les clauses
-\CodeInline{requires} pour exprimer les prémisses du lemme, et les clauses
+\CodeInline{requires} pour exprimer les prémisses du lemme et les clauses
 \CodeInline{ensures} pour exprimer la conclusion du lemme. Les variables
 quantifiées universellement peuvent rester quantifiées ou correspondre à un
 paramètre de la fonction. Plus précisément, si une variable est uniquement liée
@@ -144,7 +144,7 @@ aux prémisses ou uniquement aux conclusions, elle peut rester une variable
 quantifiée, à supposer qu'il ne soit pas nécessaire de la lier à une variable
 du code de preuve (puisque qu'une variable quantifiée n'est pas visible depuis
 le code C). Si elle est liée aux prémisses et conclusions, elle doit être un
-paramètre de la fonction (puisqu'ACSL ne nous permet pas de quantifier une
+paramètre de la fonction (puisque ACSL ne nous permet pas de quantifier une
 variable pour un contrat de fonction entier).
 
 
@@ -208,21 +208,11 @@ sont liés à la fois aux prémisses et aux conclusions, elles doivent être des
 paramètres, c'est par exemple le cas ici pour les variables \CodeInline{arr}
 et \CodeInline{len}, tandis que pour les variables quantifiées dans les
 prédicats :
-
-
-
 \CodeBlockInput[4][8]{c}{lemma-function-1-2.c}
-
-
 puisqu'elles ne sont respectivement liées qu'aux prémisses et aux conclusions
 restent universellement quantifiées (même si elles sont cachées dans les
-prédicats). Nous pourrions avoir écris le contrat comme ceci :
-
-
-
+prédicats). Nous pourrions avoir écrit le contrat comme ceci :
 \CodeBlockInput[15][32]{c}{lemma-function-1-3.c}
-
-
 où nous voyons parfaitement que les variables sont toujours universellement
 quantifiées. Cependant, nous ne sommes pas obligés de les maintenir quantifiées
 universellement, et nous pourrions parfaitement les transformer en paramètres
@@ -246,12 +236,12 @@ notre conclusion » en tant que prémisse d'un nouveau lemme :
 
 
 Tous ces lemmes énoncent la même relation globale, la différence est liée à la
-quantité d'information requises pour les instancier (et par conséquent la
+quantité d'informations requises pour les instancier (et par conséquent la
 précision de la propriété que nous obtenons en retour).
 
 
 Finalement, présentons un dernier usage des fonctions lemmes. Dans tous les
-exemples précédent, nous avons considéré des variables universellement quantifiées.
+exemples précédents, nous avons considéré des variables universellement quantifiées.
 En fait, ce que nous avons dit précédemment est aussi applicable aux variables
 existentiellement quantifiées : si elles sont liées aux prémisses et aux
 conclusions, elles doivent être des paramètres, sinon elles peuvent donner lieu
@@ -322,7 +312,7 @@ plusieurs labels :
 \end{CodeBlock}
 
 
-Les fonctions lemmes ne nous fournissent pas de mécanisme équivalent
+Les fonctions lemmes ne nous fournissent pas de mécanisme équivalent,
 car elles sont simplement des fonctions C normales, qui ne peuvent pas prendre
 de labels comme entrée. Regardons ce que nous pouvons faire à ce sujet.
 
@@ -371,22 +361,18 @@ Nous utiliserons le lemme suivant :
 \CodeBlockInput[4][11]{c}{lemma-macro-2-1.c}
 
 
-Avec pour objectif de prouver le programme suivante :
-
-
+Avec pour objectif de prouver le programme suivant :
 \CodeBlockInput[13][29]{c}{lemma-macro-2-1.c}
-
-
 où le lemme \CodeInline{shift\_ptr} est nécessaire pour prouver que la
 postcondition de \CodeInline{callee} depuis la postcondition de
 \CodeInline{shift\_array}. Notre but est bien sûr de ne pas avoir besoin du
-lemme en le remplaçant par une macro lemme.
+lemme en le remplaçant par une macro-lemme.
 
 
 Il n'y a pas de guide précis pour concevoir une macro utilisée pour injecter
 un code de preuve. Cependant, la plupart des lemmes énoncés à propos de labels
 multiples sont relativement similaires dans leur manière de lier les labels.
-Illustrons donc avec cet exemple ; la plupart du temps concevoir une macro dans
+Illustrons donc avec cet exemple ; la plupart du temps, concevoir une macro dans
 une telle situation suivra plus ou moins ce schéma.
 
 
@@ -425,7 +411,7 @@ Ensuite nous créons notre fonction de contexte :
 Décomposons ce code, en commençant par la fonction de contexte. En entrée, nous
 recevons les variables du lemme. Nous énonçons également quelques propriétés à
 propos des bornes des entiers considérés, généralement cela devrait simplement
-être les préconditions qui ne sont pas liées aux états mémoire, ou liées au
+être les préconditions qui ne sont pas liées aux états mémoire ou liées au
 premier état mémoire. Ensuite, nous introduisons le label \CodeInline{L1} et nous
 appelons la fonction \CodeInline{assign\_array} qui nous amène au label
 \CodeInline{L2}. Le rôle de cet appel est de s'assurer que WP créera un nouvel
@@ -508,7 +494,7 @@ notre fonction ne peut être utilisée que pour les types qui peuvent être
 convertis de manière sure vers \CodeInline{size\_t}. Cependant, cette limitation
 n'est généralement pas un problème : nous avons juste à exprimer notre
 spécification dans le type le plus gros que nous avons à considérer dans notre
-programme et la plupart du temps cela sera suffisant. Et si ce n'est pas le cas,
+programme et la plupart du temps, cela sera suffisant. Et si ce n'est pas le cas,
 nous pouvons par exemple dupliquer le lemme pour les types qui nous intéressent.
 La plupart du temps cette limitation est largement gérable puisque nous
 travaillons avec les types utilisés dans le programme à prouver.
@@ -572,10 +558,8 @@ gros contextes de preuve. En fonction de la puissance de la machine sur laquelle
 la preuve est lancée, la preuve pourrait approcher les 120 secondes (ce qui est
 déjà long pour un solveur SMT). Dans cet exemple, nous illustrerons les trois
 cas d'usage que nous avons vu du code fantôme jusqu'ici :
-
-
 \begin{itemize}
-    \item écris directement un code pour construire une preuve,
+    \item écrire directement un code pour construire une preuve,
     \item écrire (et utiliser) des fonctions lemmes,
     \item écrire (et utiliser) des macros lemmes.
 \end{itemize}
@@ -585,14 +569,10 @@ Nous utilisons également des assertions pour rendre le contexte de preuve plus
 riche afin que les solveurs SMT puissent prouver les propriétés qui nous intéressent.
 Certaines parties des annotations que nous avons écrites précédemment seront
 équivalentes à ce que nous avons fait précédemment. Nous rappellerons leur
-but dans chaque fonction. Ensuite, nous utilisons la même définition axiomatiques
+but dans chaque fonction. Ensuite, nous utilisons la même définition axiomatique
 pour le comptage d'occurrences. De plus, nous conservons ces définitions de
 prédicats :
-
-
 \CodeBlockInput[25][42]{c}{insert-sort-auto.c}
-
-
 puisque nous en avons besoin, ainsi que le lemme à propos de la transitivité du
 comptage d'occurrences, puisqu'il était prouvé automatiquement par les solveurs
 SMT (nous pouvons donc le garder puisqu'il ne nécessite pas de preuve interactive
@@ -612,7 +592,7 @@ nous avons écrit trois assertions :
 La première nous assure que le début du tableau où nous avons inséré une valeur
 est une permutation de la même plage de valeur avant l'appel à \CodeInline{insert}.
 Comme c'est la postcondition de la fonction, elle n'est pas nécessaire, mais nous
-la conservons la pour illustration. La dernière assertion est la propriété que
+la conservons pour illustration. La dernière assertion est la propriété que
 nous voulons prouver pour obtenir suffisamment de connaissance pour que le
 lemme à propos de la transitivité de la permutation soit utilisé (et montre qu'à
 la fin du bloc de la boucle, puisque le tableau est une permutation du tableau
@@ -624,7 +604,7 @@ La seconde assertion dit que la seconde partie du tableau reste inchangée, et n
 voulons utiliser cette connaissance pour montrer que le nombre d'occurrences des
 valeurs n'a pas changé. Ici, nous pourrions utiliser une combinaison des
 fonctions et macros lemmes pour prouver que la plage complète est une
-permutation (comme nous le ferons pour l'autre fonction). Cependant ici, écrire
+permutation (comme nous le ferons pour l'autre fonction). Cependant, écrire
 directement le code est un peu plus simple et requiert moins de preuves (comme
 nous le verrons plus tard), écrivons donc directement le code qui permet de
 prouver notre propriété.
@@ -639,12 +619,8 @@ changé pour une partie de notre tableau. En utilisant une boucle avec
 \CodeInline{permutation{L,PI}(a, beg, j)}, nous pouvons continuer le comptage des
 occurrences pour le reste de notre tableau, avec la connaissance que la fin n'a
 pas changé (quand \CodeInline{i+1} est plus petit que \CodeInline{end} sinon
-nous n'avons simplement plus rien à compter):
-
-
+nous n'avons simplement plus rien à compter) :
 \CodeBlockInput[275][291]{c}{insert-sort-auto-proved.c}
-
-
 ce qui est suffisant pour assurer que la fonction \CodeInline{insertion\_sort}
 est conforme à sa spécification à condition de finir la preuve de la fonction
 \CodeInline{insert}. Cette seconde fonction réalise des actions plus
@@ -662,8 +638,6 @@ simple ici. En effet, la seconde partie du tableau a été « tournée » ce qui
 rend la propriété un peu plus complexe. Du coup, commençons par séparer notre
 tableau à la position d'insertion en deux parties, où nous montrons
 respectivement que :
-
-
 \begin{itemize}
     \item pour la première partie, puisqu'elle est inchangée, pour tout $v$
           le nombre d'occurrences n'a pas changé non plus ;
@@ -693,7 +667,7 @@ du tableau. En effet, pour établir cela pour le tableau original, nous devons
 appeler la fonction sur le tableau original pour lequel nous ne connaissons pas
 encore la valeur de $i$. Par conséquent, écrivons une autre version de la
 propriété « \textit{split} » qui nous montrer que nous pouvons couper le tableau à toute
-position, donc rendons la variable \CodeInline{split} universellement quantifiée,
+position, donc rendons la variable \CodeInline{split} universellement quantifiée
 et utilisons la fonction précédente pour montrer que cette nouvelle propriété est
 vraie.
 
@@ -740,11 +714,7 @@ La fonction \CodeInline{unchanged\_permutation\_premise} assure que nous avons
 modifié le tableau (et donc créé un nouvel état mémoire) et que le tableau est
 inchangé entre la précondition et la postcondition. Nous pouvons construire
 notre macro lemme :
-
-
 \CodeBlockInput[135][143]{c}{insert-sort-auto-proved.c}
-
-
 qui correspond presque à ce que nous avons écrit pour \CodeInline{insert\_sort},
 et utiliser cette macro là où nous en avons besoin dans la fonction
 \CodeInline{insert}.
@@ -771,7 +741,7 @@ même). À nouveau, nous nous reposons sur la fonction \CodeInline{split} pour c
 séparément les éléments décalés et l'élément qui est déplacé de la fin vers le
 début. Cependant, l'appel correspondant dans le tableau original doit à nouveau
 être réalisée avant le code qui modifie le tableau original (voir ligne 12) dans
-le code précédent, et nouvs devons prendre cela en compte quand nous insérerons
+le code précédent, et nous devons prendre cela en compte quand nous insérerons
 notre utilisation de la macro dans la fonction \CodeInline{insert}.
 
 
@@ -926,7 +896,7 @@ d'occurrences de \CodeInline{v} est positif. \CodeInline{occ\_monotonic} peut
 
 
 Finalement, la fonction \CodeInline{occ\_pos\_exists} doit traduire le contrat
-de la fonction précédente en utilisant une variable quantifiée existentitellement,
+de la fonction précédente en utilisant une variable quantifiée existentiellement
 et utiliser la fonction précédente pour obtenir gratuitement la preuve.
 
 

--- a/french/proof-methodologies/lemma-functions.tex
+++ b/french/proof-methodologies/lemma-functions.tex
@@ -144,7 +144,7 @@ aux prémisses ou uniquement aux conclusions, elle peut rester une variable
 quantifiée, à supposer qu'il ne soit pas nécessaire de la lier à une variable
 du code de preuve (puisque qu'une variable quantifiée n'est pas visible depuis
 le code C). Si elle est liée aux prémisses et conclusions, elle doit être un
-paramètre de la fonction (puisque ACSL ne nous permet pas de quantifier une
+paramètre de la fonction (puisqu'ACSL ne nous permet pas de quantifier une
 variable pour un contrat de fonction entier).
 
 
@@ -366,7 +366,7 @@ Avec pour objectif de prouver le programme suivant :
 où le lemme \CodeInline{shift\_ptr} est nécessaire pour prouver que la
 postcondition de \CodeInline{callee} depuis la postcondition de
 \CodeInline{shift\_array}. Notre but est bien sûr de ne pas avoir besoin du
-lemme en le remplaçant par une macro-lemme.
+lemme en le remplaçant par une macro lemme.
 
 
 Il n'y a pas de guide précis pour concevoir une macro utilisée pour injecter

--- a/french/proof-methodologies/lemma-functions.tex
+++ b/french/proof-methodologies/lemma-functions.tex
@@ -288,7 +288,7 @@ découverte n'est effectuée que dans une branche où l'on a trouvé une cellule
 correspond à la valeur recherchée.
 
 
-Nous prouvons que le second comportement respecte la postcondition en montrant
+Nous prouvons que le second comportement satisfait la postcondition en montrant
 qu'il mène à une contradiction. S'il n'y a pas de cellule dont la valeur est
 \CodeInline{v}, alors le nombre d'occurrences de \CodeInline{v} est 0. C'est
 exprimé grâce au second invariant qui nous dit qu'aucun \CodeInline{v} n'a été
@@ -434,7 +434,7 @@ d'établir les prémisses. En effet, si nous regardons le contrat de
 \CodeInline{assign\_array}, nous voyons qu'elle assigne le tableau (ce qui
 garantit la création d'un nouvel état mémoire) et en postcondition, elle assure
 que le contenu du tableau, entre la pré et la postcondition (donc, quand nous
-l'appelons : \CodeInline{L1} et \CodeInline{L2}), respecte les prémisses de notre
+l'appelons, \CodeInline{L1} et \CodeInline{L2}) satisfont les prémisses de notre
 lemme (que l'on répète en ligne 15, en ajoutant une assertion). Ensuite nous
 utilisons notre macro \CodeInline{shift\_ptr} (qui contiendra par la suite notre
 code de preuve), et nous voulons être capables de prouver la postcondition de
@@ -646,7 +646,7 @@ nous n'avons simplement plus rien à compter):
 
 
 ce qui est suffisant pour assurer que la fonction \CodeInline{insertion\_sort}
-respecte sa spécification à condition de finir la preuve de la fonction
+est conforme à sa spécification à condition de finir la preuve de la fonction
 \CodeInline{insert}. Cette seconde fonction réalise des actions plus
 complexes, nous partirons de cette version annotée :
 

--- a/french/proof-methodologies/minimal-contracts.tex
+++ b/french/proof-methodologies/minimal-contracts.tex
@@ -122,9 +122,9 @@ regardant l'assertion générée par le plugin RTE :
 Nous devons donc vérifier que :
 
 \begin{itemize}
-\item le pointeur que nous avons reçu est valide,
+\item le pointeur que la fonction reçoit est valide,
 \item \CodeInline{*p+1} ne fait pas de débordement,
-\item nous respectons le contrat de la fonction \CodeInline{search}.
+\item la précondition de la fonction \CodeInline{search} est satisfaite.
 \end{itemize}
 
 
@@ -149,8 +149,9 @@ L'avantage le plus évident de cette approche est le fait qu'elle permet de gara
 qu'un programme ne contient pas d'erreurs à l'exécution dans toute fonction d'un
 module ou d'un programme en (relative) isolation des autres fonctions. De plus,
 cette absence d'erreurs à l'exécution est garantie pour tout usage de la fonction
-dont l'appel respecte ses préconditions. Cela permet de gagner une certaine confiance
-dans un système avec une approche dont le coût est relativement raisonnable.
+dont l'appel satisfait ses préconditions. Cela permet de gagner une certaine
+confiance dans un système avec une approche dont le coût est relativement
+raisonnable.
 
 
 

--- a/french/proof-methodologies/minimal-contracts.tex
+++ b/french/proof-methodologies/minimal-contracts.tex
@@ -1,7 +1,7 @@
 Nous avons vu que la preuve d'un programme permet de vérifier deux aspects
 principaux à propos de sa correction ; d'abord que le programme ne contient pas
 d'erreur d'exécution, et ensuite que le programme répond correctement à sa
-spécification. Cependant, il est parfois difficile d'obtenir le second aspect,
+spécification. Cependant, il est parfois difficile d'obtenir le second aspect
 et le premier est déjà une étape intéressante pour la correction de notre programme.
 
 
@@ -69,7 +69,7 @@ contextes dans lesquels la fonction est appelée, une fois que nous avons
 prouvée l'absence d'erreur d'exécution dans cette fonction.
 
 
-\levelThreeTitle{Exemple: la fonction recherche}
+\levelThreeTitle{Exemple : la fonction recherche}
 
 
 Maintenant que nous avons le principe en tête, travaillons avec un exemple un peu
@@ -120,7 +120,6 @@ regardant l'assertion générée par le plugin RTE :
 
 
 Nous devons donc vérifier que :
-
 \begin{itemize}
 \item le pointeur que la fonction reçoit est valide,
 \item \CodeInline{*p+1} ne fait pas de débordement,

--- a/french/proof-methodologies/triggering-lemmas.tex
+++ b/french/proof-methodologies/triggering-lemmas.tex
@@ -136,7 +136,7 @@ pouvons regarder la condition de vérification générée pour la dernière asse
 
 Alors que nous devons prouver exactement la même propriété qu'avant (avec un peu
 de renommage), nous pouvons voir que nous avons une autre manière de la prouver.
-En effet en combinant ces propriétés :
+En effet, en combinant ces propriétés :
 
 
 \begin{CodeBlock}{text}
@@ -262,7 +262,7 @@ La fonction \CodeInline{insertion\_sort} visite chaque valeur, du début du tabl
 jusqu'à la fin. Pour chaque valeur $v$, elle est insérée (en utilisant la fonction
 \CodeInline{insert}) à la bonne place dans la plage des valeurs déjà triées (et qui
 se trouvent dans le début du tableau), en décalant les éléments jusqu'à
-recontrer un élément qui est plus petit que $v$, ou le début du tableau.
+rencontrer un élément qui est plus petit que $v$, ou le début du tableau.
 
 
 
@@ -295,7 +295,7 @@ valeurs déjà visitées : nous insérons chaque valeur à la bonne position.
 
 Maintenant, nous pouvons fournir un contrat à la fonction d'insertion. La
 fonction requière que la plage de valeurs considérée soit triée du début jusqu'à
-l'avant dernière valeur. En échange elle doit garantir que la plage finale soit
+l'avant-dernière valeur. En échange elle doit garantir que la plage finale soit
 triée et soit une permutation des valeurs originales :
 
 
@@ -312,7 +312,7 @@ cas : une plage de valeur est une permutation d'elle-même, ou deux (et seulemen
 deux) valeurs ont été changées, ou finalement la permutation d'une permutation est
 une permutation. Mais aucun de ces cas ne peut être appliqué à notre fonction
 d'insertion puisque la plage obtenue ne l'est pas par une succession d'échanges de
-valeurs, et les deux autres cas ne peuvent évidemment pas s'appliquer ici.
+valeurs et les deux autres cas ne peuvent évidemment pas s'appliquer ici.
 
 
 
@@ -341,7 +341,7 @@ entendu aussi le cas pour notre plage de valeur « décalée ».
 
 
 Déterminons quels sont les lemmes requis en considérant d'abord la fonction
-\CodeInline{insert\_sort}. La seule propriété non-prouvée est l'invariant qui
+\CodeInline{insert\_sort}. La seule propriété non prouvée est l'invariant qui
 exprime que le tableau est une permutation du tableau original. Comment
 pouvons-nous le déduire ? (Nous nous intéresserons aux preuves de ces lemmes
 plus tard).
@@ -453,14 +453,11 @@ pour cela.
 
 
 Tout d'abord, donnons un invariant pour la permutation :
-
 \begin{itemize}
     \item nous fournissons les bornes de \CodeInline{i},
     \item nous indiquons que la première partie du tableau est inchangée,
-    \item nous indiquons que la seconde partie est décalée vers la gauche.
+    \item nous indiquons que la seconde partie est décalée vers la gauche,
 \end{itemize}
-
-
 et nous ajoutons quelques assertions pour vérifier quelques propriétés d'intérêt :
 \begin{itemize}
     \item d'abord, pour déclencher \CodeInline{unchanged\_permutation}, nous
@@ -580,7 +577,7 @@ la même).
 
 Pour prouver \CodeInline{union\_permutation}, nous instancions le lemme
 \CodeInline{l\_occurrences\_union}. Finalement, le lemme
-\CodeInline{transitive\_permutation} est prouvée automatiquement par transitivité
+\CodeInline{transitive\_permutation} est prouvé automatiquement par transitivité
 de l'égalité.
 
 
@@ -709,7 +706,6 @@ cellules qui suivent la cellule modifiée.
 
 
 Nous avons donc besoin de deux lemmes :
-
 \begin{itemize}
     \item \CodeInline{sum\_separable} doit exprimer que nous pouvons séparer le
           tableau en deux sous parties, compter dans chaque partie et sommer les

--- a/french/proof-methodologies/triggering-lemmas.tex
+++ b/french/proof-methodologies/triggering-lemmas.tex
@@ -11,7 +11,7 @@ maximiser l'automatisation. Cependant, plus les propriétés que nous voulons
 prouver sont complexes, plus il sera difficile d'obtenir automatiquement toute
 la preuve. Par conséquent, nous devons souvent aider les outils pour terminer
 la vérification. Nous faisons souvent cela en fournissant plus d'annotations
-pour aider le processus de génération des obligations de preuve. Ajouter un
+pour aider le processus de génération des conditions de vérification. Ajouter un
 invariant de boucle est par exemple une manière de fournir les informations
 nécessaires pour produire le raisonnement par induction permettant son analyse,
 alors que les prouveurs automatiques sont plutôt mauvais à cet exercice.
@@ -27,7 +27,7 @@ fournissons manuellement de l'information aux outils.
 Dans cette section, nous allons voir plus en détails comment nous pouvons
 utiliser des assertions pour guider la preuve. En ajoutant des assertions, nous
 créons une certaine base de connaissances (des propriétés que nous savons vraies),
-qui sont collectées par le générateur d'obligations de preuve pendant le calcul
+qui sont collectées par le générateur de conditions de vérification pendant le calcul
 de WP et qui sont données aux prouveurs automatiques qui ont par conséquent plus
 d'information et peuvent potentiellement prouver des propriétés plus complexes.
 
@@ -37,7 +37,7 @@ d'information et peuvent potentiellement prouver des propriétés plus complexes
 
 Pour comprendre exactement le bénéfice que représente l'ajout d'assertions dans
 les annotations d'un programme, commençons par regarder de plus près les
-obligations de preuve générées par WP à partir du code source annoté et comment
+conditions de vérification générées par WP à partir du code source annoté et comment
 les assertions sont prises en compte. Pour cela, nous allons utiliser le prédicat
 suivant (qui ressemble furieusement au théorème de Pythagore) :
 
@@ -57,10 +57,11 @@ Regardons d'abord cet exemple :
 Ici, nous avons spécifié une précondition suffisamment complexe pour que WP ne
 puisse par directement deviner les valeurs en entrée de fonction. En fait, ces
 valeurs sont exactement : \CodeInline{*x == 3}, \CodeInline{*y == 4} et
-\CodeInline{*z == 5}. Maintenant, si nous regardons l'obligation de preuve générée
-pour notre première assertion, nous pouvons voir ceci (il faut bien sélectionner
-la vue « \textit{Full Context} » ou « \textit{Raw obligation} » - elles ne sont pas exactement
-identiques mais assez similaires, la première est juste légèrement plus jolie) :
+\CodeInline{*z == 5}. Maintenant, si nous regardons la condition de vérification
+générée pour notre première assertion, nous pouvons voir ceci (il faut bien
+sélectionner la vue « \textit{Full Context} » ou « \textit{Raw obligation} » -
+elles ne sont pas exactement identiques, mais assez similaires, la première est
+juste légèrement plus jolie) :
 
 
 \image{context_e1_a1}
@@ -69,7 +70,7 @@ identiques mais assez similaires, la première est juste légèrement plus jolie
 Nous y voyons les différentes contraintes que nous avons formulées comme préconditions
 de fonction (notons que les valeurs ne sont pas exactement les mêmes, et que quelques
 propriétés supplémentaires ont été générées). Maintenant, regardons plutôt
-l'obligation de preuve générées pour la seconde assertion (notons que nous avons
+la condition de vérification générée pour la seconde assertion (notons que nous avons
 édité les captures d'écran restantes de cette section pour nous concentrer sur ce
 qui est important, les autres propriétés pouvant être ignorées dans notre cas) :
 
@@ -81,7 +82,7 @@ Ici, nous pouvons voir que dans le contexte utilisable pour la preuve de la seco
 assertion, WP a collecté et ajouté la première assertion et en a fait une supposition.
 WP considère que les solveurs SMT peuvent supposer que cette propriété est vraie.
 Cela signifie que les prouveurs peuvent l'utiliser, mais également qu'elle doit être
-prouvée pour l'obligation de preuve actuelle soit complètement vérifiée.
+prouvée pour que la condition de vérification actuelle soit complètement vérifiée.
 
 
 Notons que WP ne collecte que ce qu'il trouve sur les différents chemins d'exécution
@@ -111,8 +112,8 @@ vérifier que le triangle résultant est rectangle.
 
 
 Ici, le solveur déroulera probablement le prédicat et vérifiera directement
-que la propriété qui y est définie est vraie. En effet, depuis l'obligation de
-preuve, il n'y a pas vraiment d'autres informations qui pourrait nous
+que la propriété qui y est définie est vraie. En effet, depuis la condition de
+vérification, il n'y a pas vraiment d'autres informations qui pourrait nous
 amener à obtenir une preuve. Maintenant, ajoutons de l'information dans les
 annotations :
 
@@ -126,7 +127,7 @@ Nous prouvons d'abord que si nous multiplions par 2 chacune des valeurs, le
 prédicat est vrai pour les nouvelles valeurs. Le solveur prouvera d'abord
 la même propriété, bien sûr, mais ce n'est pas ce que nous voulons montrer ici.
 Nous ajoutons ensuite que chaque valeur a été multipliée par 2. Maintenant, nous
-pouvons regarder l'obligation de preuve générée pour la dernière assertion :
+pouvons regarder la condition de vérification générée pour la dernière assertion :
 
 
 \image{context_e3}
@@ -204,7 +205,7 @@ Et nous voulons prouver le programme suivant :
 \CodeBlockInput[21][31]{c}{trigger_1_1.c}
 
 
-Cependant, nous pouvons voir que la preuve échoue sur l'obligation de preuve
+Cependant, nous pouvons voir que la preuve échoue sur la condition de vérification
 suivante (nous avons, à nouveau, retiré les éléments qui ne sont pas intéressants
 pour notre explication) :
 
@@ -212,7 +213,7 @@ pour notre explication) :
 \image{trigger_1_1}
 
 
-D'après cela, notre prouver automatique semble incapable d'utiliser l'un des
+D'après cela, notre prouveur automatique semble incapable d'utiliser l'un des
 axiomes de notre définition : soit il ne peut pas montrer qu'après l'appel
 \CodeInline{g(y)}, \CodeInline{P(x)} est toujours vraie, soit il le peut, et
 dans ce cas, cela veut dire qu'il n'arrive pas à montrer que cela implique
@@ -229,7 +230,7 @@ arrive à montrer \CodeInline{P(x)} après l'appel :
 Il semble que malgré le fait qu'il est clair que \CodeInline{*x} n'a pas changé
 pendant l'appel \CodeInline{g(y)}, et donc que \CodeInline{eq\{Pre, Here\}(x)}
 est vraie après l'appel, puisque la propriété n'est pas directement fournie dans
-notre obligation de preuve, le prouveur automatique n'utilise pas l'axiome
+notre condition de vérification, le prouveur automatique n'utilise pas l'axiome
 \CodeInline{ax\_2} correspondant. Fournissons donc cette information au prouveur
 automatique :
 
@@ -238,7 +239,7 @@ automatique :
 
 
 
-Maintenant, tout est prouvé. Si nous regardons l'obligation de preuve générée,
+Maintenant, tout est prouvé. Si nous regardons la condition de vérification générée,
 nous pouvons voir que l'information nécessaire est bien fournie, ce qui permet
 au prouveur automatique d'en faire usage :
 
@@ -589,18 +590,18 @@ de l'égalité.
 Il n'y a pas de guide précis à propos de quand utiliser des assertions ou non.
 La plupart du temps nous les utilisons d'abord pour comprendre pourquoi certaines
 preuves échouent en exprimant des propriétés dont nous pensons qu'elles sont vraies
-à un point particulier de programme. De plus, il n'est pas rare que les obligations
-de preuve soient longues ou un peu complexes à lire directement. Bien utiliser les
-assertion nécessite que l'on garde en tête les lemmes déjà exprimés pour savoir
-quelle assertion utiliser pour déclencher l'usage d'un lemme nous amenant à la
-propriété voulue. S'il n'y a pas de tel lemme, par exemple parce que la preuve
-de la propriété voulue nécessite un raisonnement par induction à propos d'une
-propriété ou d'une valeur, nous avons probablement besoin d'ajouter un nouveau
-lemme.
+à un point particulier de programme. De plus, il n'est pas rare que les conditions
+de vérification soient longues ou un peu complexes à lire directement. Bien
+utiliser les assertions nécessite que l'on garde en tête les lemmes déjà exprimés
+pour savoir quelle assertion utiliser pour déclencher l'usage d'un lemme nous
+amenant à la propriété voulue. S'il n'y a pas de tel lemme, par exemple parce
+que la preuve de la propriété voulue nécessite un raisonnement par induction à
+propos d'une propriété ou d'une valeur, nous avons probablement besoin d'ajouter
+un nouveau lemme.
 
 
 Avec un peu d'expérience, l'utilisation des assertions et des lemmes devient de
-plus en plus naturelle. Cependant il est important de garder en tête qu'il est
+plus en plus naturelle. Cependant, il est important de garder en tête qu'il est
 facile d'abuser de cela. Plus nous ajoutons de lemmes et d'assertions, plus notre
 contexte de preuve est riche et est susceptible de contenir les informations
 nécessaires à la preuve. Cependant, il y a aussi un risque d'ajouter trop
@@ -662,8 +663,8 @@ Les assertions devraient ressembler à :
 
 Une autre manière d'ajouter de l'information au contexte est d'utiliser du
 code fantôme. Par exemple, la valeur de vérité d'une conditionnelle apparaît
-dans le contexte d'une obligation de preuve. Modifier les annotations pour que
-le code ressemble à :
+dans le contexte d'une condition de vérification. Modifier les annotations pour
+que le code ressemble à :
 
 
 \begin{CodeBlock}{c}
@@ -679,7 +680,8 @@ void example(int* x){
 }
 \end{CodeBlock}
 
-Comparer l'obligation de preuve générée pour chaque assertion avec les précédentes.
+Comparer la condition de vérification générée pour chaque assertion avec les
+précédentes.
 
 
 Finalement, nous pouvons remarquer que « la valeur pointée a été augmentée ou

--- a/french/statements/basic.tex
+++ b/french/statements/basic.tex
@@ -1,15 +1,15 @@
 \levelThreeTitle{Affectation}
 
 
-L'affectation est l'opération la plus basique que l'on puisse avoir dans un 
-langage (mise à part l'opération « ne rien faire » qui manque singulièrement 
+L'affectation est l'opération la plus basique que l'on puisse avoir dans un
+langage (mise à part l'opération « ne rien faire » qui manque singulièrement
 d'intérêt). Le calcul de plus faible précondition associé est le suivant :
 $$wp(x = E , Post) := Post[x \leftarrow E]$$
 
 
 où la notation $P[x \leftarrow E]$ signifie « la propriété $P$ où $x$ est remplacé
 par $E$ ». Ce qui correspond ici à « la postcondition $Post$ où $x$ a été
-remplacé par $E$ ». Dans l'idée, pour que la formule en postcondition d'une 
+remplacé par $E$ ». Dans l'idée, pour que la formule en postcondition d'une
 affectation de $x$ à $E$ soit vraie, il faut qu'en remplaçant chaque occurrence de
 $x$ dans la formule par $E$, on obtienne une propriété qui est vraie. Par exemple :
 
@@ -38,7 +38,7 @@ x = 43 * c ;
 
 
 
-Pour calculer la précondition de l'affectation, nous avons remplacé chaque 
+Pour calculer la précondition de l'affectation, nous avons remplacé chaque
 occurrence de $x$ dans la postcondition, par la valeur $E = 43*c$ affectée.
 Si notre programme était de la forme:
 
@@ -61,20 +61,20 @@ que non, une telle formule n'est pas vraie.
 
 
 
-Nous pouvons donc écrire la règle d'inférence pour le triplet de Hoare de 
+Nous pouvons donc écrire la règle d'inférence pour le triplet de Hoare de
 l'affectation, où l'on prend en compte le calcul de plus faible précondition :
 $$\dfrac{}{\{Q[x \leftarrow E] \}\quad x = E \quad\{ Q \}}$$
 
 
 Nous noterons qu'il n'y a pas de prémisse à vérifier. Cela veut-il dire que le
-triplet est nécessairement vrai ? Oui. Mais cela ne dit pas si la précondition 
-est respectée par le programme où se trouve l'instruction, ni que cette 
+triplet est nécessairement vrai ? Oui. Mais cela ne dit pas si la précondition
+est satisfaite par le programme où se trouve l'instruction, ni que cette
 précondition est possible. C'est ce travail qu'effectuent ensuite les prouveurs
 automatiques.
 
 
 
-Par exemple, nous pouvons demander la vérification de la ligne suivante avec 
+Par exemple, nous pouvons demander la vérification de la ligne suivante avec
 Frama-C :
 
 
@@ -86,18 +86,18 @@ int a = 42;
 
 
 
-Ce qui est, bien entendu, prouvé directement par Qed car c'est une simple 
+Ce qui est, bien entendu, prouvé directement par Qed car c'est une simple
 application de la règle de l'affectation.
 
 
 
 \begin{Information}
 Notons que d'après la norme C, l'opération d'affectation est une expression
-et non une instruction. C'est ce qui nous permet par exemple d'écrire 
+et non une instruction. C'est ce qui nous permet par exemple d'écrire
 \CodeInline{if( (a = foo()) == 42)}. Dans Frama-C, une affectation sera toujours une
-instruction. En effet, si une affectation est présente au sein d'une 
+instruction. En effet, si une affectation est présente au sein d'une
 expression plus complexe, le module de création de l'arbre de syntaxe abstraite
-du programme analysé effectue une étape de normalisation qui crée 
+du programme analysé effectue une étape de normalisation qui crée
 systématiquement une instruction séparée.
 \end{Information}
 
@@ -107,7 +107,7 @@ systématiquement une instruction séparée.
 
 
 En C, grâce aux (à cause des ?) pointeurs, nous pouvons avoir des programmes avec
-des alias, à savoir que deux pointeurs peuvent pointer vers la même position en 
+des alias, à savoir que deux pointeurs peuvent pointer vers la même position en
 mémoire. Notre calcul de plus faible précondition doit donc considérer ce genre
 de cas. Par exemple, nous pouvons regarder ce triplet de Hoare :
 
@@ -121,7 +121,7 @@ de cas. Par exemple, nous pouvons regarder ce triplet de Hoare :
 
 Ce triplet de Hoare est correct, puisque \CodeInline{p} et \CodeInline{q} sont en
 alias, modifier la valeur \CodeInline{*p} modifie aussi la valeur \CodeInline{*q},
-par conséquent, ces deux expressions s'évaluent à $1$ et la postcondition est 
+par conséquent, ces deux expressions s'évaluent à $1$ et la postcondition est
 vraie. Cependant, regardons ce que nous obtenons en appliquant le calcul de plus
 faible précondition précédemment défini pour l'affectation sur cet exemple:
 
@@ -132,11 +132,11 @@ $wp(*p = 1, *p + *q = 2)$ & $= (*p + *q = 2)[*p \leftarrow 1]$\\
 \end{tabular}
 
 
-Nous obtenons la plus faible précondition: \CodeInline{1 + *q == 2}, et donc 
+Nous obtenons la plus faible précondition: \CodeInline{1 + *q == 2}, et donc
 nous pourrions déduire que la plus faible précondition est \CodeInline{*q == 1}
 (ce qui est vrai), mais nous ne sommes pas en mesure de conclure que le programme
 est correct, car rien dans notre formule ne nous indique quelque chose comme:
-\CodeInline{p == q ==> *q == 1}. En fait, ici, nous voudrions être capable de 
+\CodeInline{p == q ==> *q == 1}. En fait, ici, nous voudrions être capable de
 calculer une plus faible précondition de la forme:
 
 
@@ -180,7 +180,7 @@ parce que la spécification de la fonction nous l'indique).
 
 
 Maintenant, nous pouvons changer légèrement notre calcul de plus faible précondition
-pour le cas particulier des affectations à travers un pointeur. Pour cela, nous 
+pour le cas particulier des affectations à travers un pointeur. Pour cela, nous
 considérons que nous avons dans le programme une variable implicite $M$ qui modélise
 la mémoire, et nous définissons l'affectation d'une position en mémoire comme une mise
 à jour de cette variable, de telle manière à ce que cette position contienne maintenant
@@ -188,7 +188,7 @@ l'expression fournie lors de l'affectation :
 
 $$wp(*x = E, Q) = Q[M \leftarrow M[x \mapsto E]]$$
 
-Évaluer une valeur pointée $*x$ dans une formule consiste maintenant à utiliser 
+Évaluer une valeur pointée $*x$ dans une formule consiste maintenant à utiliser
 l'opération $get$ pour demander la valeur à la mémoire. Nous pouvons donc
 appliquer notre calcul de plus faible précondition à notre programme précédent :
 
@@ -222,7 +222,7 @@ le programme est correct.
 
 Le plugin WP ne fonctionne par exactement comme cela. En particulier, cela dépend du
 modèle mémoire sélectionné pour réaliser la preuve, qui fait différentes hypothèses à
-propos de la manière dont la mémoire est organisée. Pour le modèle mémoire que nous 
+propos de la manière dont la mémoire est organisée. Pour le modèle mémoire que nous
 utilisons, le modèle mémoire typé, WP crée différentes variables pour la mémoire.
 Cela dit, regardons tout de même les conditions de vérification générées par WP pour la
 postcondition de la fonction \CodeInline{swap} :
@@ -240,31 +240,31 @@ nous avons défini précédemment (voir par exemple la définition de la variabl
 \levelThreeTitle{Séquence d'instructions}
 
 
-Pour qu'une instruction soit valide, il faut que sa précondition nous 
-permette, par cette instruction, de passer à la postcondition voulue. 
-Maintenant, nous avons besoin d'enchaîner ce processus d'une 
+Pour qu'une instruction soit valide, il faut que sa précondition nous
+permette, par cette instruction, de passer à la postcondition voulue.
+Maintenant, nous avons besoin d'enchaîner ce processus d'une
 instruction à une autre. L'idée est alors que la postcondition assurée par la
-première instruction soit compatible avec la précondition demandée par la 
-deuxième et que ce processus puisse se répéter pour la troisième instruction, 
+première instruction soit compatible avec la précondition demandée par la
+deuxième et que ce processus puisse se répéter pour la troisième instruction,
 etc.
 
 
 
-La règle d'inférence correspondant à cette idée, utilisant les triplets de 
+La règle d'inférence correspondant à cette idée, utilisant les triplets de
 Hoare est la suivante:
 $$\dfrac{\{P\}\quad S1 \quad \{R\} \ \ \ \{R\}\quad S2 \quad \{Q\}}{\{P\}\quad S1 ;\ S2 \quad \{Q\}}$$
 
 
 
-Pour vérifier que la séquence d'instructions $S1;\ S2$ (NB : où $S1$ et $S2$ 
-peuvent elles-mêmes être des séquences d'instructions), nous passons par une 
-propriété intermédiaire qui est à la fois la précondition de $S2$ et la 
-postcondition de $S1$. Cependant, rien ne nous indique pour l'instant 
+Pour vérifier que la séquence d'instructions $S1;\ S2$ (NB : où $S1$ et $S2$
+peuvent elles-mêmes être des séquences d'instructions), nous passons par une
+propriété intermédiaire qui est à la fois la précondition de $S2$ et la
+postcondition de $S1$. Cependant, rien ne nous indique pour l'instant
 comment obtenir les propriétés $P$ et $R$.
 
 
 
-Le calcul de plus faible précondition $wp$ nous dit simplement que la 
+Le calcul de plus faible précondition $wp$ nous dit simplement que la
 propriété intermédiaire $R$ est trouvée par calcul de plus faible précondition
 de la deuxième instruction. Et que la propriété $P$ est trouvée en calculant la
 plus faible précondition de la première instruction. La plus faible précondition
@@ -273,7 +273,7 @@ $$wp(S1;\ S2 , Post) := wp(S1, wp(S2, Post) )$$
 
 
 
-Le plugin WP de Frama-C fait ce calcul pour nous, c'est pour cela que nous 
+Le plugin WP de Frama-C fait ce calcul pour nous, c'est pour cela que nous
 n'avons pas besoin d'écrire les assertions entre chaque ligne de code.
 
 
@@ -298,7 +298,7 @@ int main(){
 
 Notons que lorsque nous avons plus de deux instructions, nous pouvons simplement
 considérer que la dernière instruction est la seconde instruction de notre règle
-et que toutes les instructions qui la précèdent forment la première « instruction ». 
+et que toutes les instructions qui la précèdent forment la première « instruction ».
 De cette manière, nous remontons bien les instructions une à une dans notre
 raisonnement, par exemple avec le programme précédent :
 
@@ -314,12 +314,12 @@ raisonnement, par exemple avec le programme précédent :
 \end{center}
 
 Nous pouvons par calcul de plus faibles préconditions construire la propriété
-$Q_{-1}$ à partir de $Q$ et $i_3$, ce qui nous permet de déduire $Q_{-2}$, à 
+$Q_{-1}$ à partir de $Q$ et $i_3$, ce qui nous permet de déduire $Q_{-2}$, à
 partir de $Q_{-1}$ et $i_2$ et finalement $P$ avec $Q_{-2}$ et $i_1$.
 
 
 
-Nous pouvons maintenant vérifier des programmes comprenant plusieurs 
+Nous pouvons maintenant vérifier des programmes comprenant plusieurs
 instructions ; il est temps d'y ajouter un peu de structure.
 
 
@@ -328,20 +328,20 @@ instructions ; il est temps d'y ajouter un peu de structure.
 
 
 Pour qu'un branchement conditionnel soit valide, il faut que la postcondition
-soit atteignable par les deux banches, depuis la même précondition, à ceci 
-près que chacune des branches aura une information supplémentaire : le fait 
+soit atteignable par les deux banches, depuis la même précondition, à ceci
+près que chacune des branches aura une information supplémentaire : le fait
 que la condition était vraie dans un cas et fausse dans l'autre.
 
 
 
 Comme avec la séquence d'instructions, nous aurons donc deux points à vérifier
-(pour éviter de confondre les accolades, j'utilise la syntaxe 
+(pour éviter de confondre les accolades, j'utilise la syntaxe
 $if\ B\ then\ S1\ else\ S2$) :
 $$\dfrac{\{P \wedge B\}\quad S1\quad \{Q\} \quad \quad \{P \wedge \neg B\}\quad S2\quad \{Q\}}{\{P\}\quad if\quad B\quad then\quad S1\quad else\quad S2 \quad \{Q\}}$$
 
 
 
-Nos deux prémisses sont donc la vérification que lorsque nous avons la 
+Nos deux prémisses sont donc la vérification que lorsque nous avons la
 précondition et que nous passons dans la branche \CodeInline{if}, nous atteignons bien la
 postcondition, et que lorsque nous avons la précondition et que nous passons
 dans la branche \CodeInline{else}, nous obtenons bien également la postcondition.
@@ -352,8 +352,8 @@ Le calcul de précondition de $wp$ pour la conditionnelle est le suivant :
 $$wp(if\ B\ then\ S1\ else\ S2 , Post) := (B \Rightarrow wp(S1, Post)) \wedge (\neg B \Rightarrow wp(S2, Post))$$
 
 
-À savoir que $B$ doit impliquer la précondition la plus faible de $S1$, pour 
-pouvoir l'exécuter sans erreur vers la postcondition, et que $\neg B$ doit 
+À savoir que $B$ doit impliquer la précondition la plus faible de $S1$, pour
+pouvoir l'exécuter sans erreur vers la postcondition, et que $\neg B$ doit
 impliquer la précondition la plus faible de $S2$ (pour la même raison).
 
 
@@ -378,13 +378,13 @@ $$P \wedge \neg B \Rightarrow Q$$
 
 
 
-En résumé, si la condition du \CodeInline{if} est fausse, cela veut dire que la 
-postcondition de l'instruction conditionnelle globale est déjà vérifiée avant de 
+En résumé, si la condition du \CodeInline{if} est fausse, cela veut dire que la
+postcondition de l'instruction conditionnelle globale est déjà vérifiée avant de
 rentrer dans le \CodeInline{else} (puisqu'il ne fait rien).
 
 
 
-Par exemple, nous pourrions vouloir remettre une configuration $c$ à une valeur 
+Par exemple, nous pourrions vouloir remettre une configuration $c$ à une valeur
 par défaut si elle a mal été configurée par un utilisateur du programme :
 
 
@@ -430,9 +430,9 @@ La formule est bien vérifiable : quelle que soit l'évaluation de $\neg (c \in 
 
 
 
-Parfois, il peut être utile pour la preuve de renforcer une postcondition ou 
+Parfois, il peut être utile pour la preuve de renforcer une postcondition ou
 d'affaiblir une précondition. Si la première sera souvent établie par nos soins
-pour faciliter le travail du prouveur, la seconde est plus souvent vérifiée 
+pour faciliter le travail du prouveur, la seconde est plus souvent vérifiée
 par l'outil à l'issue du calcul de plus faible précondition.
 
 
@@ -448,16 +448,16 @@ Hoare mais également des formules à vérifier)
 
 
 Par exemple, si notre postcondition est trop complexe, elle risque de générer
-une plus faible précondition trop compliquée et de rendre le calcul des 
+une plus faible précondition trop compliquée et de rendre le calcul des
 prouveurs difficile. Nous pouvons alors créer une postcondition intermédiaire
-$SQ$, plus simple, mais plus restreinte et impliquant la vraie postcondition. 
+$SQ$, plus simple, mais plus restreinte et impliquant la vraie postcondition.
 C'est la partie $SQ \Rightarrow Q$.
 
 
 
-Inversement, le calcul de précondition générera généralement une formule 
+Inversement, le calcul de précondition générera généralement une formule
 compliquée et souvent plus faible que la précondition que nous souhaitons
-accepter en entrée. Dans ce cas, c'est notre outil qui s'occupera de vérifier 
+accepter en entrée. Dans ce cas, c'est notre outil qui s'occupera de vérifier
 l'implication entre ce que nous voulons et ce qui est nécessaire pour que notre
 code soit valide. C'est la partie $P \Rightarrow WP$.
 
@@ -465,7 +465,7 @@ code soit valide. C'est la partie $P \Rightarrow WP$.
 
 Nous pouvons par exemple illustrer cela avec le code qui suit. Notons bien qu'ici,
 le code pourrait tout à fait être prouvé par l'intermédiaire de WP sans ajouter des
-affaiblissements et renforcements de propriétés, car le code est très simple, il 
+affaiblissements et renforcements de propriétés, car le code est très simple, il
 s'agit juste d'illustrer la règle de conséquence.
 
 
@@ -496,10 +496,10 @@ int constrained_times_10(int a){
 
 
 Ici, nous voulons avoir un résultat compris entre 0 et 100. Mais nous savons que
-le code ne produira pas un résultat sortant des bornes 10 à 90. Donc nous 
+le code ne produira pas un résultat sortant des bornes 10 à 90. Donc nous
 renforçons la postcondition avec une assertion que \CodeInline{res}, le résultat, est compris
 entre 0 et 90 à la fin. Le calcul de plus faible précondition, sur cette propriété,
-et avec l'affectation \CodeInline{res = 10*a} nous produit une plus faible précondition 
+et avec l'affectation \CodeInline{res = 10*a} nous produit une plus faible précondition
 \CodeInline{1 <= a <= 9} et nous savons finalement que \CodeInline{2 <= a <= 8} nous donne cette garantie.
 
 
@@ -516,12 +516,12 @@ défaut produit par WP, elles sont juste présentes pour l'illustration.
 \label{l3:statements-basic-constancy}
 
 
-Certaines séquences d'instructions peuvent concerner et faire intervenir des 
+Certaines séquences d'instructions peuvent concerner et faire intervenir des
 variables différentes. Ainsi, il peut arriver que nous initialisions et manipulions
-un certain nombre de variables, que nous commencions à utiliser certaines d'entre 
+un certain nombre de variables, que nous commencions à utiliser certaines d'entre
 elles, puis que nous les délaissions au profit d'autres pendant un temps. Quand un
-tel cas apparaît, nous avons envie que l'outil ne se préoccupe que des variables 
-qui sont susceptibles d'être modifiées pour avoir des propriétés les plus légères 
+tel cas apparaît, nous avons envie que l'outil ne se préoccupe que des variables
+qui sont susceptibles d'être modifiées pour avoir des propriétés les plus légères
 possibles.
 
 
@@ -531,9 +531,9 @@ $$\dfrac{\{P\}\quad c\quad \{Q\}}{\{P \wedge R\}\quad c\quad \{Q \wedge R\}}$$
 
 
 
-où $c$ ne modifie aucune variable entrant en jeu dans $R$. Ce qui nous dit : « pour 
+où $c$ ne modifie aucune variable entrant en jeu dans $R$. Ce qui nous dit : « pour
 vérifier le triplet, débarrassons-nous des parties de la formule qui concernent des
-variables qui ne sont pas manipulées par $c$ et prouvons le nouveau triplet ». 
+variables qui ne sont pas manipulées par $c$ et prouvons le nouveau triplet ».
 Cependant, il faut prendre garde à ne pas supprimer trop d'information, au risque
 de ne plus pouvoir prouver nos propriétés.
 
@@ -617,7 +617,7 @@ int foo(int a, int b){
 
 
 Dans le bloc \CodeInline{else}, n'ayant que connaissance du fait que \CodeInline{a} est compris
-entre -99 et 0, et ne sachant rien à propos de \CodeInline{b}, nous pourrions 
+entre -99 et 0, et ne sachant rien à propos de \CodeInline{b}, nous pourrions
 difficilement savoir si le calcul \CodeInline{a += b} produit une valeur supérieure
 strict à 0 pour \CodeInline{a}.
 
@@ -625,25 +625,25 @@ strict à 0 pour \CodeInline{a}.
 
 Naturellement ici, WP prouvera la fonction sans problème, puisqu'il transporte
 de lui-même les propriétés qui lui sont nécessaires pour la preuve. En fait,
-l'analyse des variables qui sont nécessaires ou non (et l'application, par 
+l'analyse des variables qui sont nécessaires ou non (et l'application, par
 conséquent de la règle de constance) est réalisée directement par WP.
 
 
 
-Notons finalement que la règle de constance est une instance de la règle de 
+Notons finalement que la règle de constance est une instance de la règle de
 conséquence :
 $$\dfrac{P \wedge R \Rightarrow P \quad \{P\}\quad c\quad \{Q\} \quad Q \Rightarrow Q \wedge R}{\{P \wedge R\}\quad c\quad \{Q \wedge R\}}$$
 
 
 
-Si les variables de $R$ n'ont pas été modifiées par l'opération (qui par contre, 
-modifie les variables de $P$ pour former $Q$), alors effectivement 
+Si les variables de $R$ n'ont pas été modifiées par l'opération (qui par contre,
+modifie les variables de $P$ pour former $Q$), alors effectivement
 $P \wedge R \Rightarrow P$ et $Q \Rightarrow Q \wedge R$.
 
 
 
 \levelThreeTitle{Exercices}
- 
+
 
 \levelFourTitle{Une série d'affectations}
 
@@ -667,8 +667,8 @@ int function(int x, int y){
 \end{CodeBlock}
 
 
-En utilisant la bonne règle d'inférence, en déduire que le programme respecte le 
-contrat fixé pour cette fonction.
+En utilisant la bonne règle d'inférence, en déduire que le programme est
+conforme au contrat fixé pour cette fonction.
 
 
 \levelFourTitle{Branche « \textit{then} » vide dans une conditionnelle}
@@ -713,7 +713,7 @@ peut être réécrit comme :
 
 \begin{CodeBlock}{c}
 if(cond1){
-  if(cond2){    
+  if(cond2){
     // code
   }
 }
@@ -734,9 +734,9 @@ Calculer à la main la plus faible précondition du programme suivant :
 
 
 \begin{CodeBlock}{c}
-/*@ 
-  requires -5 <= y <= 5 ; 
-  requires -5 <= x <= 5 ; 
+/*@
+  requires -5 <= y <= 5 ;
+  requires -5 <= x <= 5 ;
   ensures  -15 <= \result <= 25 ;
 */
 int function(int x, int y){
@@ -745,13 +745,13 @@ int function(int x, int y){
   if(x < 0){
     x = 0 ;
   }
-  
+
   if(y < 0){
     x += 5 ;
   } else {
     x -= 5 ;
   }
-  
+
   res = x - y ;
 
   return res ;
@@ -760,5 +760,5 @@ int function(int x, int y){
 
 
 
-En utilisant la bonne règle d'inférence, en déduire que le programme respecte le 
-contrat fixé pour cette fonction.
+En utilisant la bonne règle d'inférence, en déduire que le programme est
+conforme au contrat fixé pour cette fonction.

--- a/french/statements/basic.tex
+++ b/french/statements/basic.tex
@@ -3,10 +3,8 @@
 
 L'affectation est l'opération la plus basique que l'on puisse avoir dans un
 langage (mise à part l'opération « ne rien faire » qui manque singulièrement
-d'intérêt). Le calcul de plus faible précondition associé est le suivant :
+d'intérêt). Le calcul de plus faible précondition associée est le suivant :
 $$wp(x = E , Post) := Post[x \leftarrow E]$$
-
-
 où la notation $P[x \leftarrow E]$ signifie « la propriété $P$ où $x$ est remplacé
 par $E$ ». Ce qui correspond ici à « la postcondition $Post$ où $x$ a été
 remplacé par $E$ ». Dans l'idée, pour que la formule en postcondition d'une
@@ -40,19 +38,13 @@ x = 43 * c ;
 
 Pour calculer la précondition de l'affectation, nous avons remplacé chaque
 occurrence de $x$ dans la postcondition, par la valeur $E = 43*c$ affectée.
-Si notre programme était de la forme:
-
-
-
+Si notre programme était de la forme :
 \begin{CodeBlock}{c}
 int c = 6 ;
 // { 43*c = 258 }
 x = 43 * c ;
 // { x = 258 }
 \end{CodeBlock}
-
-
-
 nous pourrions alors fournir la formule « $43*6 = 258$ » à notre prouveur automatique
 afin qu'il détermine si cette formule peut effectivement être satisfaite. Ce à quoi
 il répondrait évidemment « oui », puisque cette propriété est très simple à vérifier.
@@ -123,7 +115,7 @@ Ce triplet de Hoare est correct, puisque \CodeInline{p} et \CodeInline{q} sont e
 alias, modifier la valeur \CodeInline{*p} modifie aussi la valeur \CodeInline{*q},
 par conséquent, ces deux expressions s'évaluent à $1$ et la postcondition est
 vraie. Cependant, regardons ce que nous obtenons en appliquant le calcul de plus
-faible précondition précédemment défini pour l'affectation sur cet exemple:
+faible précondition précédemment défini pour l'affectation sur cet exemple :
 
 
 \begin{tabular}{ll}
@@ -132,12 +124,12 @@ $wp(*p = 1, *p + *q = 2)$ & $= (*p + *q = 2)[*p \leftarrow 1]$\\
 \end{tabular}
 
 
-Nous obtenons la plus faible précondition: \CodeInline{1 + *q == 2}, et donc
+Nous obtenons la plus faible précondition : \CodeInline{1 + *q == 2}, et donc
 nous pourrions déduire que la plus faible précondition est \CodeInline{*q == 1}
 (ce qui est vrai), mais nous ne sommes pas en mesure de conclure que le programme
-est correct, car rien dans notre formule ne nous indique quelque chose comme:
+est correct, car rien dans notre formule ne nous indique quelque chose comme :
 \CodeInline{p == q ==> *q == 1}. En fait, ici, nous voudrions être capable de
-calculer une plus faible précondition de la forme:
+calculer une plus faible précondition de la forme :
 
 
 \begin{tabular}{ll}
@@ -148,7 +140,7 @@ $wp(*p = 1, *p + *q = 2)$ & $= (1 + *q = 2 \vee q = p)$\\
 
 Pour cela, nous devons faire attention à la notion d'aliasing. Une manière
 commune de le faire est de considérer que la mémoire est une variable particulière
-du programme (nommons la $M$) sur laquelle nous pouvons effectuer deux opérations :
+du programme (nommons-la $M$) sur laquelle nous pouvons effectuer deux opérations :
 obtenir la valeur d'un emplacement particulier $m$ en mémoire (qui nous retourne une
 expression) et changer la valeur à une position mémoire $l$ pour y placer une nouvelle
 valeur $v$ (qui nous retourne la nouvelle mémoire obtenue).
@@ -191,8 +183,6 @@ $$wp(*x = E, Q) = Q[M \leftarrow M[x \mapsto E]]$$
 Évaluer une valeur pointée $*x$ dans une formule consiste maintenant à utiliser
 l'opération $get$ pour demander la valeur à la mémoire. Nous pouvons donc
 appliquer notre calcul de plus faible précondition à notre programme précédent :
-
-
 \begin{tabular}{lll}
   $wp(*p = 1, *p + *q = 2)$
   & $= (*p + *q = 2)[M \leftarrow M[p \mapsto 1]]$ & (1)\\
@@ -203,7 +193,6 @@ appliquer notre calcul de plus faible précondition à notre programme précéde
   & $= (\texttt{if}\ q = p\ \texttt{then}\ 1+1 = 2\ \texttt{else}\ 1+M[q] = 2)$ & (6)\\
   & $= (q = p \vee M[q] = 1)$ & (7)
 \end{tabular}
-
 \begin{enumerate}
 \item nous devons appliquer la règle pour l'affectation de valeur pointée, mais
   pour cela, nous devons d'abord introduire $M$,
@@ -213,10 +202,9 @@ appliquer notre calcul de plus faible précondition à notre programme précéde
 \item nous utilisons la définition de $get$ pour $q$\\
   ($M[p \mapsto 1][q] = \texttt{if}\ q = p\ \texttt{then}\ 1\ \texttt{else}\ M[q]$)
 \item nous appliquons quelques simplifications sur la formule \dots
-\item \dots et nous pouvons finalement conclure que $M[q] = 1$ ou $p = q$.
+\item \dots et nous pouvons finalement conclure que $M[q] = 1$ ou $p = q$,
 \end{enumerate}
-
-et comme dans notre programme nous savons que $p = q$, nous pouvons conclure que
+et comme dans notre programme, nous savons que $p = q$, nous pouvons conclure que
 le programme est correct.
 
 
@@ -233,7 +221,7 @@ postcondition de la fonction \CodeInline{swap} :
 Nous pouvons voir, au début de la définition de cette condition de vérification qu'une
 variable \CodeInline{Mint\_0} représentant une mémoire pour les valeurs de type entier
 a été créée, et que cette mémoire est mise à jour et accédée à l'aide des opérateurs que
-nous avons défini précédemment (voir par exemple la définition de la variable
+nous avons définis précédemment (voir par exemple la définition de la variable
 \CodeInline{x\_2}).
 
 
@@ -251,7 +239,7 @@ etc.
 
 
 La règle d'inférence correspondant à cette idée, utilisant les triplets de
-Hoare est la suivante:
+Hoare est la suivante :
 $$\dfrac{\{P\}\quad S1 \quad \{R\} \ \ \ \{R\}\quad S2 \quad \{Q\}}{\{P\}\quad S1 ;\ S2 \quad \{Q\}}$$
 
 
@@ -505,9 +493,9 @@ et avec l'affectation \CodeInline{res = 10*a} nous produit une plus faible préc
 
 
 Quand une preuve a du mal à être réalisée sur un code plus complexe, écrire des
-assertions produisant des postconditions plus fortes mais qui forment des formules
+assertions produisant des postconditions plus fortes, mais qui forment des formules
 plus simples peut souvent nous aider. Notons que dans le code précédent, les lignes
-\CodeInline{P\_imply\_WP} et \CodeInline{SQ\_imply\_Q} ne sont jamais utiles car c'est le raisonnement par
+\CodeInline{P\_imply\_WP} et \CodeInline{SQ\_imply\_Q} ne sont jamais utiles, car c'est le raisonnement par
 défaut produit par WP, elles sont juste présentes pour l'illustration.
 
 
@@ -519,7 +507,7 @@ défaut produit par WP, elles sont juste présentes pour l'illustration.
 Certaines séquences d'instructions peuvent concerner et faire intervenir des
 variables différentes. Ainsi, il peut arriver que nous initialisions et manipulions
 un certain nombre de variables, que nous commencions à utiliser certaines d'entre
-elles, puis que nous les délaissions au profit d'autres pendant un temps. Quand un
+elles, puis les délaissions au profit d'autres pendant un temps. Quand un
 tel cas apparaît, nous avons envie que l'outil ne se préoccupe que des variables
 qui sont susceptibles d'être modifiées pour avoir des propriétés les plus légères
 possibles.
@@ -528,9 +516,6 @@ possibles.
 
 La règle d'inférence qui définit ce raisonnement est la suivante :
 $$\dfrac{\{P\}\quad c\quad \{Q\}}{\{P \wedge R\}\quad c\quad \{Q \wedge R\}}$$
-
-
-
 où $c$ ne modifie aucune variable entrant en jeu dans $R$. Ce qui nous dit : « pour
 vérifier le triplet, débarrassons-nous des parties de la formule qui concernent des
 variables qui ne sont pas manipulées par $c$ et prouvons le nouveau triplet ».
@@ -619,7 +604,7 @@ int foo(int a, int b){
 Dans le bloc \CodeInline{else}, n'ayant que connaissance du fait que \CodeInline{a} est compris
 entre -99 et 0, et ne sachant rien à propos de \CodeInline{b}, nous pourrions
 difficilement savoir si le calcul \CodeInline{a += b} produit une valeur supérieure
-strict à 0 pour \CodeInline{a}.
+stricte à 0 pour \CodeInline{a}.
 
 
 
@@ -682,14 +667,14 @@ Pour les deux questions qui suivent, nous avons uniquement besoin des règles d'
 et pas du calcul de plus faible précondition.
 
 
-Montrer que lorsqu'au lieu de la branche « \textit{else} », c'est la branche « \textit{then} » qui est
+Montrer que lorsque, au lieu de la branche « \textit{else} », c'est la branche « \textit{then} » qui est
 vide, la postcondition de structure conditionnelle est vérifiée par la conjonction de
 la précondition et de la condition de notre structure conditionnelle (puisque
 la branche « \textit{else} » est la seule à potentiellement modifier l'état de
 la mémoire).
 
 
-Montrer que si les deux branches sont vide, la structure conditionnelle est juste une
+Montrer que si les deux branches sont vides, la structure conditionnelle est juste une
 instruction \textit{skip}.
 
 

--- a/french/statements/introduction.tex
+++ b/french/statements/introduction.tex
@@ -1,11 +1,11 @@
 
 
 \begin{Information}
-Cette partie est plus formelle que ce nous avons vu jusqu'à maintenant. Si le 
+Cette partie est plus formelle que ce que nous avons vu jusqu'à maintenant. Si le
 lecteur souhaite se concentrer sur l'utilisation de l'outil, l'introduction de
-ce chapitre et les deux premières sections (sur les instructions de base et « le 
+ce chapitre et les deux premières sections (sur les instructions de base et « le
 bonus stage ») sont dispensables. Si ce que nous avons présenté jusqu'à maintenant
-a semblé ardu au lecteur sur un plan formel, il est également possible de réserver 
+a semblé ardu au lecteur sur un plan formel, il est également possible de réserver
 l'introduction et ces deux sections pour une deuxième lecture.
 
 Les sections sur les boucles sont en revanches indispensables. Les éléments plus
@@ -13,12 +13,12 @@ formels de ces sections seront signalés.
 \end{Information}
 
 
-Pour chaque notion en programmation C, nous associerons la règle d'inférence qui 
-lui correspond, la règle utilisée de calcul de plus faible préconditions qui la 
-régit, et des exemples d'utilisation. Pas forcément dans cet ordre et avec plus ou 
+Pour chaque notion en programmation C, nous associerons la règle d'inférence qui
+lui correspond, la règle utilisée de calcul de plus faible précondition qui la
+régit et des exemples d'utilisation. Pas forcément dans cet ordre et avec plus ou
 moins de liaison avec l'outil. Les premiers points seront plus focalisés sur la
-théorie que sur l'utilisation car ce sont les plus simples, au fur et à mesure,
-nous nous concentrerons de plus en plus sur l'outil, en particulier quand nous 
+théorie que sur l'utilisation, car ce sont les plus simples, au fur et à mesure,
+nous nous concentrerons de plus en plus sur l'outil, en particulier quand nous
 attaquerons le point concernant les boucles.
 
 
@@ -27,17 +27,9 @@ attaquerons le point concernant les boucles.
 
 
 Une règle d'inférence est de la forme :
-
-
-
-
 \begin{center}
 $\dfrac{P_1 \quad ... \quad P_n}{C}$
-
-
 \end{center}
-
-
 et signifie que pour assurer que la conclusion $C$ est vraie, il faut d'abord
 savoir que les prémisses $P_1$, ..., et $P_n$ sont vraies. Quand il n'y a
 pas de prémisses :
@@ -47,8 +39,6 @@ pas de prémisses :
 
 \begin{center}
 $\dfrac{}{\quad C \quad}$
-
-
 \end{center}
 
 
@@ -56,7 +46,7 @@ Alors, il n'y a rien à assurer pour conclure que $C$ est vraie.
 
 
 
-Inversement, pour prouver qu'une certaine prémisse est vraie, il peut être nécessaire 
+Inversement, pour prouver qu'une certaine prémisse est vraie, il peut être nécessaire
 d'utiliser une autre règle d'inférence, ce qui nous donnerait quelque
 chose comme :
 
@@ -71,7 +61,7 @@ $\dfrac{\dfrac{}{\quad P_1\quad} \quad \dfrac{P_{n_1}\quad P_{n_2}}{P_n}}{C}$
 
 
 Ce qui nous construit progressivement l'arbre de déduction de notre raisonnement.
-Dans notre raisonnement, les prémisses et conclusions manipulées seront 
+Dans notre raisonnement, les prémisses et conclusions manipulées seront
 généralement des triplets de Hoare.
 
 
@@ -91,10 +81,10 @@ $\{ P \}\quad  C\quad \{ Q \}$
 \end{center}
 
 
-Nous l'avons vu en début de tutoriel, ce triplet nous exprime que si avant 
+Nous l'avons vu en début de tutoriel, ce triplet nous exprime que si avant
 l'exécution de $C$, la propriété $P$ est vraie, et si $C$ termine, alors la
 propriété $Q$ est vraie. Par exemple, si nous reprenons notre programme de
-calcul de la valeur absolue (légèrement modifié):
+calcul de la valeur absolue (légèrement modifié) :
 
 
 
@@ -112,16 +102,16 @@ deux postconditions pour alléger la lecture) :
 
 
 
-Cependant, Hoare ne nous dit pas comment nous pouvons obtenir automatiquement la 
+Cependant, Hoare ne nous dit pas comment nous pouvons obtenir automatiquement la
 propriété \CodeInline{P} de ce programme. Ce que nous propose Dijkstra, c'est donc un moyen
-de calculer, à partir d'une postcondition $Q$ et d'une commande ou d'une liste de 
-commandes $C$, la précondition minimale assurant $Q$ après $C$. Nous pourrions 
+de calculer, à partir d'une postcondition $Q$ et d'une commande ou d'une liste de
+commandes $C$, la précondition minimale assurant $Q$ après $C$. Nous pourrions
 donc, dans le programme précédent, calculer la propriété \CodeInline{P} qui nous donne les
 garanties voulues.
 
 
 
-Nous présenterons tout au long de cette partie les différents cas de la 
+Nous présenterons tout au long de cette partie les différents cas de la
 fonction $wp$ qui, à une postcondition voulue et un programme ou une instruction,
 nous associe la plus faible précondition qui permet de l'assurer. Nous utiliserons
 cette notation pour définir le calcul correspondant à une ou plusieurs instructions :
@@ -133,22 +123,14 @@ $wp(Instruction(s), Post) := WeakestPrecondition$
 
 
 De plus la fonction $wp$ est telle qu'elle nous garantit que le triplet de Hoare :
-
-
-
-
 \begin{center}
 $\{\ wp(C,Q)\ \}\quad C\quad \{ Q \}$
-
-
 \end{center}
-
-
 est effectivement un triplet valide.
 
 
 
-Nous utiliserons souvent des assertions ACSL pour présenter les notions à 
+Nous utiliserons souvent des assertions ACSL pour présenter les notions à
 venir :
 
 
@@ -162,11 +144,9 @@ venir :
 Ces assertions correspondent en fait à des étapes intermédiaires possibles pour
 les propriétés indiquées dans nos triplets de Hoare. Nous pouvons par exemple
 reprendre le programme précédent et remplacer nos commentaires par les assertions
-ACSL correspondantes (j'ai omis \CodeInline{P} car sa valeur est en fait simplement
+ACSL correspondantes (nous omettons \CodeInline{P} car sa valeur est en fait simplement
 « vrai ») :
 
 
 
 \CodeBlockInput{c}{abs-3.c}
-
-

--- a/french/statements/loops-examples.tex
+++ b/french/statements/loops-examples.tex
@@ -1,4 +1,4 @@
-\levelThreeTitle{Exemple avec un tableau read-only}
+\levelThreeTitle{Exemple avec un tableau en lecture seule}
 \label{l3:statements-loops-examples-ro}
 
 
@@ -23,7 +23,7 @@ Cet exemple est suffisamment fourni pour introduire des notations importantes.
 
 D'abord, comme nous l'avons déjà mentionné, le prédicat \CodeInline{\textbackslash{}valid\_read} (de
 même que \CodeInline{\textbackslash{}valid}) nous permet de spécifier non seulement la validité d'une
-adresse en lecture mais également celle de tout un ensemble d'adresses
+adresse en lecture, mais également celle de tout un ensemble d'adresses
 contiguës. C'est la notation que nous avons utilisée dans cette expression :
 
 
@@ -161,7 +161,7 @@ Regardons la fonction effectuant la remise à zéro d'un tableau.
 
 
 Nous voyons que nous utilisons pour l'invariant une structure assez similaire
-à ce que nous avons utilisé pour l'exemple précédent: nous indiquons un premier
+à ce que nous avons utilisé pour l'exemple précédent : nous indiquons un premier
 invariant pour contraindre la valeur de \CodeInline{i}, et un autre qui exprime
 à chaque itération ce que nous avons appris depuis le début de l'exécution de la
 boucle (tous les éléments visités sont à $0$). Finalement, intéressons-nous à la
@@ -252,14 +252,14 @@ Et cette fois, la preuve passera.
 \levelThreeTitle{Exercices}
 
 
-Pour tous ces exercices, utiliser la commande suivante pour démarrer la vérification:
+Pour tous ces exercices, utiliser la commande suivante pour démarrer la vérification :
 
 \begin{CodeBlock}{bash}
 frama-c-gui -wp -wp-rte -warn-unsigned-overflow -warn-unsigned-downcast your-file.c
 \end{CodeBlock}
 
 
-\levelFourTitle{Fonctions sans modification : Forall, Exists, ...}
+\levelFourTitle{Fonctions sans modification : For all, Exists, ...}
 
 
 Actuellement, les pointeurs de fonction ne sont pas directement supportés par WP.
@@ -312,7 +312,7 @@ devrait contenir un quantificateur existentiel.
 
 La fonction suivante cherche la position d'une valeur fournie en entrée dans
 un tableau, en supposant que le tableau est trié. D'abord, considérons que la
-longueur du tableau est fournie en tant qu'int et utilisons des valeurs de ce
+longueur du tableau est fournie en tant qu'\CodeInline{int} et utilisons des valeurs de ce
 même type pour gérer les indices. Nous pouvons noter qu'il y a deux comportements
 à cette fonction : soit la valeur existe dans le tableau (et le résultat est
 l'indice de cette valeur) ou pas (et le résultat est -1).
@@ -323,7 +323,7 @@ l'indice de cette valeur) ou pas (et le résultat est -1).
 
 Cette fonction est un petit peu complexe à prouver, voici quelques conseils
 pour en venir à bout. D'abord, la longueur de la fonction est reçue en utilisant
-un type int, donc nous devons poser une restriction sur cette longueur en
+un type \CodeInline{int}, donc nous devons poser une restriction sur cette longueur en
 précondition pour qu'elle soit cohérente. Ensuite, l'un des invariants de la
 boucle devrait indiquer les bornes des valeurs \CodeInline{low} et
 \CodeInline{up}, mais nous pouvons noter que pour chacune d'elles, l'une des
@@ -343,7 +343,7 @@ soit une borne exclue de la recherche.
 Écrire, spécifier et prouver la fonction qui ajoute deux vecteurs dans un
 troisième. Fixer des contraintes arbitraires sur les valeurs d'entrée pour
 gérer le débordement des entiers. Considérer que le vecteur est résultant est
-spacialement séparé des vecteurs d'entrée. En revanche, le même vecteur devrait
+spatialement séparé des vecteurs d'entrée. En revanche, le même vecteur devrait
 pouvoir être utilisé pour les deux vecteurs d'entrée.
 
 \CodeBlockInput[7][9]{c}{ex-4-add-vectors.c}
@@ -353,7 +353,7 @@ pouvoir être utilisé pour les deux vecteurs d'entrée.
 
 
 Écrire, spécifier et prouver la fonction qui inverse un vecteur en place.
-Prendre garde à la partie non-modifiée du vecteur à une itération donnée de la
+Prendre garde à la partie non modifiée du vecteur à une itération donnée de la
 boucle. Utiliser la fonction \CodeInline{swap} précédemment prouvée.
 
 
@@ -391,7 +391,7 @@ dans la plage source :
 Essentiellement, en copiant des éléments dans cet ordre, nous pouvons les
 décaler depuis la fin d'une plage vers le début. En revanche, cela signifie que
 nous devons être plus précis dans notre contrat : nous ne garantissons plus une
-égalité avec le tableau source mais avec les \emph{anciennes} valeurs du tableau
+égalité avec le tableau source, mais avec les \emph{anciennes} valeurs du tableau
 source. Nous devons également être plus précis dans notre invariant, d'abord en
 spécifiant aussi la relation avec l'état précédent de la mémoire, et ensuite en
 ajoutant un invariant qui nous dit que le tableau source n'est pas modifié entre

--- a/french/statements/loops-examples.tex
+++ b/french/statements/loops-examples.tex
@@ -73,10 +73,10 @@ différence fondamentale entre l'usage de \CodeInline{exists} et celui de \CodeI
 
 
 Avec \CodeInline{\textbackslash{}forall type a ; p(a) ==> q(a)}, la restriction (\CodeInline{p}) est suivie
-par une implication. Pour tout élément, s'il respecte une première propriété
+par une implication. Pour tout élément, s'il satisfait une première propriété
 (\CodeInline{p}), alors il doit vérifier la seconde propriété \CodeInline{q}. Si nous mettions un ET
 comme pour le « il existe » (que nous expliquerons ensuite), cela voudrait dire que
-nous voulons que tout élément respecte à la fois les deux propriétés. Parfois,
+nous voulons que tout élément vérifie à la fois les deux propriétés. Parfois,
 cela peut être ce que nous voulons exprimer, mais cela ne correspond alors plus
 à l'idée de restreindre un ensemble dont nous voulons montrer une propriété
 particulière.
@@ -85,7 +85,7 @@ particulière.
 
 Avec \CodeInline{\textbackslash{}exists type a ; p(a) \&\& q(a)}, la restriction (\CodeInline{p}) est suivie
 par une conjonction, nous voulons qu'il existe un élément tel que cet élément
-est dans un certain état (défini par \CodeInline{p}), tout en respectant l'autre
+est dans un certain état (défini par \CodeInline{p}), tout en satisfaisant l'autre
 propriété \CodeInline{q}. Si nous mettions une implication comme pour le « pour tout »,
 alors une telle expression devient toujours vraie à moins que \CodeInline{p} soit une
 tautologie ! Pourquoi ? Existe-t-il « a » tel que p(a) implique q(a) ? Prenons

--- a/french/statements/loops.tex
+++ b/french/statements/loops.tex
@@ -1,7 +1,7 @@
 Les boucles ont besoin d'un traitement de faveur dans la vérification déductive
 de programmes. Ce sont les seules structures de contrôle qui vont nécessiter un
-travail conséquent de notre part. Nous ne pouvons pas y échapper car sans les
-boucles nous pouvons difficilement prouver des programmes intéressants.
+travail conséquent de notre part. Nous ne pouvons pas y échapper, car sans les
+boucles, nous pouvons difficilement prouver des programmes intéressants.
 
 
 
@@ -15,7 +15,7 @@ poser la question suivante : pourquoi les boucles sont-elles compliquées ?
 
 
 La nature des boucles rend leur analyse difficile. Lorsque nous faisons nos
-raisonnements arrières, il nous faut une règle capable de dire à partir de la
+raisonnements arrière, il nous faut une règle capable de dire à partir de la
 postcondition quelle est la précondition d'une certaine séquence
 d'instructions. Problème : nous ne pouvons \textit{a priori} pas déduire combien de
 fois la boucle s'exécutera et donc, nous ne pouvons pas non
@@ -56,9 +56,6 @@ $10$.
 
 
 Le raisonnement produit par l'outil pour vérifier un invariant $I$ sera donc :
-
-
-
 \begin{itemize}
 \item vérifions que $I$ est vrai au début de la boucle (établissement),
 \item vérifions que si $I$ est vrai avant de commencer un tour, alors $I$ est vrai après (préservation).
@@ -86,10 +83,9 @@ Détaillons cette formule :
 vulgairement la « précondition » de la boucle,
 \item la deuxième partie de la conjonction ($(B \wedge I) \Rightarrow wp(c, I)$)
 correspond à la vérification du travail effectué par le corps de la boucle :
-
 \begin{itemize}
 \item la précondition que nous connaissons du corps de la boucle (notons $KWP$,
-« \textit{Known WP} ») est ($KWP = B \wedge I$). Soit le fait que nous sommes
+« \textit{Known WP} ») est ($KWP = B \wedge I$). Soit, le fait que nous sommes
 rentrés dedans ($B$ est vrai), et que l'invariant est vérifié à ce moment
 ($I$, qui est vrai avant de commencer la boucle par (1), et dont veut
 vérifier qu'il sera vrai en fin de bloc de la boucle (2)),
@@ -102,7 +98,7 @@ $KWP \Rightarrow wp(c, I)$, soit $(B \wedge I) \Rightarrow wp(c, I)$,
 \item * cela correspond à une application de la règle de conséquence expliquée
 précédemment.
 \end{itemize}
-\item finalement, la dernière partie ($(\neg B \wedge I) \Rightarrow Post$)
+\item Finalement, la dernière partie ($(\neg B \wedge I) \Rightarrow Post$)
 nous dit que le fait d'être sorti de la boucle ($\neg B$), tout en ayant
 maintenu l'invariant $I$, doit impliquer la postcondition voulue pour la
 boucle.
@@ -152,7 +148,7 @@ en début de boucle :
 Pourquoi ? Parce que tout au long de la boucle \CodeInline{i} sera bien compris entre
 0 et 30 \textbf{inclus}. 30 est même la valeur qui nous permettra de sortir de la
 boucle. Plus encore, une des propriétés demandées par le calcul de plus faible
-préconditions sur les boucles est que lorsque l'on invalide la condition de la
+précondition sur les boucles est que lorsque l'on invalide la condition de la
 boucle, par la connaissance de l'invariant, on peut prouver la postcondition
 (Formellement : $(\neg B \wedge I) \Rightarrow Post$).
 
@@ -177,7 +173,7 @@ Goals} » :
 Nous remarquons bien que WP décompose la preuve de l'invariant en deux parties :
 l'établissement de l'invariant et sa préservation. WP produit exactement le
 raisonnement décrit plus haut pour la preuve de l'assertion. Dans les versions
-récentes de Frama-C, Qed est devenu particulièrement puissant, et la condition
+récentes de Frama-C, Qed est devenu particulièrement puissant et la condition
 de vérification générée ne le montre pas (affichant simplement « \textit{True} »).
 En utilisant l'option \CodeInline{-wp-no-simpl} au lancement, nous pouvons quand
 même voir la condition de vérification correspondante :
@@ -206,13 +202,13 @@ Il semble que non.
 
 
 
-\levelThreeTitle{La clause « assigns » ... pour les boucles}
+\levelThreeTitle{La clause \texttt{assigns} ... pour les boucles}
 
 
 En fait, à propos des boucles, WP ne considère vraiment \textit{que} ce que lui
 fournit l'utilisateur pour faire ses déductions. Et ici l'invariant ne nous dit
 rien à propos de l'évolution de la valeur de \CodeInline{h}. Nous pourrions signaler
-l'invariance de toute variable du programme mais ce serait beaucoup d'efforts.
+l'invariance de toute variable du programme, mais ce serait beaucoup d'efforts.
 ACSL nous propose plus simplement d'ajouter des annotations \CodeInline{assigns} pour
 les boucles. Toute autre variable est considérée invariante. Par exemple :
 
@@ -273,7 +269,7 @@ la boucle est triviale : la condition de la boucle est « VRAI » et aucune inst
 du bloc de la boucle ne permet d'en sortir puisque le bloc ne contient pas de code du
 tout. Comme nous sommes en correction partielle, et que le calcul ne termine pas, nous
 pouvons prouver n'importe quoi au sujet du code qui suit la partie non terminante. Si,
-en revanche, la non-terminaison est non-triviale, il y a peu de chances que l'assertion
+en revanche, la non-terminaison est non triviale, il y a peu de chances que l'assertion
 soit prouvée.
 
 
@@ -291,7 +287,7 @@ de l'appel à \CodeInline{abs} avec la valeur \CodeInline{INT\_MIN}.
 
 
 Pour prouver la terminaison d'une boucle, nous utilisons la notion de variant de
-boucle. Le variant de boucle n'est pas une propriété mais une valeur. C'est une
+boucle. Le variant de boucle n'est pas une propriété, mais une valeur. C'est une
 expression faisant intervenir des éléments modifiés par la boucle et donnant une
 borne supérieure sur le nombre d'itérations restant à effectuer à un tour de la
 boucle. C'est donc une expression supérieure à 0 et strictement décroissante d'un
@@ -317,7 +313,7 @@ Une nouvelle fois nous pouvons regarder les buts générés :
 
 Le variant nous génère bien deux conditions de vérification au niveau de la
 vérification :
-assurer que la valeur est positive, et assurer qu'elle décroît strictement pendant
+assurer que la valeur est positive et assurer qu'elle décroît strictement pendant
 l'exécution de la boucle. Si nous supprimons la ligne de code qui incrémente
 \CodeInline{i}, WP ne peut plus prouver que la valeur \CodeInline{30 - i} décroît strictement.
 
@@ -377,9 +373,6 @@ de cette fonction est l'ancienne valeur de \CodeInline{a} à laquelle nous avons
 
 Le calcul de plus faibles préconditions ne permet pas de sortir de la boucle des
 informations qui ne font pas partie de l'invariant. Dans un programme comme :
-
-
-
 \begin{CodeBlock}{c}
 /*@
     ensures \result == \old(a) + 10;
@@ -392,9 +385,6 @@ int add_ten(int a){
     return a;
 }
 \end{CodeBlock}
-
-
-
 en remontant les instructions depuis la postcondition, on conserve toujours les
 informations à propos de \CodeInline{a}. À l'inverse, comme mentionné plus tôt, en dehors
 de la boucle WP, ne considérera que les informations fournies par notre
@@ -472,7 +462,7 @@ d'une boucle, une condition vérifiée par un élément particulier dans une str
 de données et s'arrête quand cet élément est trouvé afin d'effectuer certaines
 opérations qui ne sont finalement pas vraiment des opérations de la boucle. D'un
 point de vue vérification, cela nous permet de simplifier le contrat associé à
-une boucle : nous savons que l'opération (potentiellement complexe) ) réalisée
+une boucle : nous savons que l'opération (potentiellement complexe) réalisée
 juste avant de sortir de la boucle ne nécessite pas d'être prise en compte dans
 l'invariant.
 
@@ -523,8 +513,8 @@ comme variant. Il est possible qu'un invariant supplémentaire soit nécessaire.
 \levelFourTitle{Loop assigns}
 
 
-Écrire une clause \CodeInline{loop assigns} pour cette boucle, de manière à ce
-que l'assertion ligne 8 soit prouvée ainsi que la clause \CodeInline{loop assigns}.
+Écrire une clause \CodeInline{loop assigns} pour cette boucle, de manière que
+l'assertion ligne 8 soit prouvée ainsi que la clause \CodeInline{loop assigns}.
 Ignorons les erreurs à l'exécution dans cet exercice.
 
 
@@ -534,7 +524,7 @@ Ignorons les erreurs à l'exécution dans cet exercice.
 
 Lorsque la preuve réussit, supprimer la clause \CodeInline{loop assigns} et
 trouver un autre moyen d'assurer que l'assertion soit vérifiée en utilisant des
-annotations différentes (notons que vous pouvons avoir besoin d'un label C dans
+annotations différentes (notons que nous pouvons avoir besoin d'un label C dans
 le code). Que peut-on déduire à propos de la clause \CodeInline{loop assigns} ?
 
 

--- a/french/statements/loops.tex
+++ b/french/statements/loops.tex
@@ -90,7 +90,7 @@ correspond à la vérification du travail effectué par le corps de la boucle :
 \begin{itemize}
 \item la précondition que nous connaissons du corps de la boucle (notons $KWP$,
 « \textit{Known WP} ») est ($KWP = B \wedge I$). Soit le fait que nous sommes
-rentrés dedans ($B$ est vrai), et que l'invariant est respecté à ce moment
+rentrés dedans ($B$ est vrai), et que l'invariant est vérifié à ce moment
 ($I$, qui est vrai avant de commencer la boucle par (1), et dont veut
 vérifier qu'il sera vrai en fin de bloc de la boucle (2)),
 \item (2) ce qu'il nous reste à vérifier c'est que $KWP$ implique la
@@ -482,7 +482,7 @@ l'invariant.
 
 \levelFourTitle{Invariant de boucle}
 
-Écrire un invariant de boucle pour la boucle suivante et prouver qu'il est respecté
+Écrire un invariant de boucle pour la boucle suivante et prouver qu'il est vérifié
 en utilisant la commande :
 
 

--- a/french/statements/loops.tex
+++ b/french/statements/loops.tex
@@ -177,10 +177,10 @@ Goals} » :
 Nous remarquons bien que WP décompose la preuve de l'invariant en deux parties :
 l'établissement de l'invariant et sa préservation. WP produit exactement le
 raisonnement décrit plus haut pour la preuve de l'assertion. Dans les versions
-récentes de Frama-C, Qed est devenu particulièrement puissant, et l'obligation de
-preuve générée ne le montre pas (affichant simplement « \textit{True} »). En utilisant
-l'option \CodeInline{-wp-no-simpl} au lancement, nous pouvons quand même voir
-l'obligation correspondante :
+récentes de Frama-C, Qed est devenu particulièrement puissant, et la condition
+de vérification générée ne le montre pas (affichant simplement « \textit{True} »).
+En utilisant l'option \CodeInline{-wp-no-simpl} au lancement, nous pouvons quand
+même voir la condition de vérification correspondante :
 
 
 
@@ -315,7 +315,8 @@ Une nouvelle fois nous pouvons regarder les buts générés :
 \image{i_30-4}
 
 
-Le variant nous génère bien deux obligations au niveau de la vérification :
+Le variant nous génère bien deux conditions de vérification au niveau de la
+vérification :
 assurer que la valeur est positive, et assurer qu'elle décroît strictement pendant
 l'exécution de la boucle. Si nous supprimons la ligne de code qui incrémente
 \CodeInline{i}, WP ne peut plus prouver que la valeur \CodeInline{30 - i} décroît strictement.


### PR DESCRIPTION
- use verification condition instead of proof obligation
- use conforms to specification instead of respect the specification
- massive spellcheck with ltex